### PR TITLE
fix networkmonitor_de_DE.desktop for the time being

### DIFF
--- a/plugin-networkmonitor/translations/networkmonitor_de_DE.desktop
+++ b/plugin-networkmonitor/translations/networkmonitor_de_DE.desktop
@@ -5,9 +5,6 @@ ServiceTypes=LxQtPanel/Plugin
 Name=Network monitor
 Comment=Displays network status and activity.
 
-
-
-
 # Translations
-Comment[de_DE]=Anwendungsmenü
-Name[de_DE]=Menü-basierter Anwendungsstarter
+Name[de]=Netzwerk Monitor
+Comment[de]=Informationen zu Status und Aktivität des Netzwerks


### PR DESCRIPTION
This PR is a successor of https://github.com/lxde/lxqt-panel/pull/110 (which I can't modify any more as it has already been merged, right?):

Despite several attempts in https://github.com/lxde/lxqt-panel/pull/110 and on mailing list the discussion whether country-specific translations are needed in German and how things should be handled otherwise respectively didn't come to a conclusion.
With regards to the upcoming release I'm fixing networkmonitor_de_DE.desktop nevertheless. Thus German users looking into LXQt won't have to see that total crap they're presented when adding Network Monitor to their panel right now.
Maybe we can discuss this subject again once Pootle is not only online but working as well.