### PR TITLE
Add a threshold which a user has to pass when scrolling on the desktopswitch plugin

### DIFF
--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -150,12 +150,19 @@ void DesktopSwitch::realign()
 }
 
 DesktopSwitchWidget::DesktopSwitchWidget():
-    QFrame()
+    QFrame(),
+    m_mouseWheelThresholdCounter(0)
 {
 }
 
 void DesktopSwitchWidget::wheelEvent(QWheelEvent *e)
 {
+    // Without some sort of threshold which has to be passed, scrolling is too sensitive
+    m_mouseWheelThresholdCounter -= e->delta();
+    // If the user hasn't scrolled far enough in one direction (positive or negative): do nothing
+    if(abs(m_mouseWheelThresholdCounter) < 100)
+        return;
+    
     int max = KWindowSystem::numberOfDesktops();
     int delta = e->delta() < 0 ? 1 : -1;
     int current = KWindowSystem::currentDesktop() + delta;
@@ -166,5 +173,6 @@ void DesktopSwitchWidget::wheelEvent(QWheelEvent *e)
     else if (current < 1)
         current = max;
 
+    m_mouseWheelThresholdCounter = 0;
     KWindowSystem::setCurrentDesktop(current);
 }

--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -156,13 +156,14 @@ DesktopSwitchWidget::DesktopSwitchWidget():
 
 void DesktopSwitchWidget::wheelEvent(QWheelEvent *e)
 {
-    int max = KWindowSystem::currentDesktop() - 1;
+    int max = KWindowSystem::numberOfDesktops();
     int delta = e->delta() < 0 ? 1 : -1;
     int current = KWindowSystem::currentDesktop() + delta;
 
-    if (current > max)
-        current = 0;
-    else if (current < 0)
+    if (current > max){
+        current = 1;
+    }
+    else if (current < 1)
         current = max;
 
     KWindowSystem::setCurrentDesktop(current);

--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -43,6 +43,9 @@ class DesktopSwitchWidget: public QFrame
     Q_OBJECT
 public:
     DesktopSwitchWidget();
+    
+private:
+    int m_mouseWheelThresholdCounter;
 
 protected:
     void wheelEvent(QWheelEvent* e);


### PR DESCRIPTION
This makes scrolling less sensitive and more usable.

Fixes lxde/lxqt#479.