### PR TITLE
Make some frequently used plugins "statically-linked" to speed up loading.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,6 @@ set(PLUGIN_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/lxqt-panel")
 add_definitions(-DPLUGIN_DIR=\"${PLUGIN_DIR}\")
 message(STATUS "Panel plugins location: ${PLUGIN_DIR}")
 
-add_subdirectory(panel)
-
 #########################################################################
 
 # Plugin system
@@ -73,11 +71,13 @@ add_subdirectory(panel)
 
 include("cmake/BuildPlugin.cmake")
 
-set(ENABLED_PLUGINS)
+set(ENABLED_PLUGINS) # list of enabled plugins
+set(STATIC_PLUGINS) # list of statically linked plugins
 
 setByDefault(CLOCK_PLUGIN Yes)
 if(CLOCK_PLUGIN)
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Clock")
+    list(APPEND STATIC_PLUGINS "clock")
     add_subdirectory(plugin-clock)
 endif()
 
@@ -109,6 +109,7 @@ endif(DOM_PLUGIN)
 
 setByDefault(DESKTOPSWITCH_PLUGIN Yes)
 if(DESKTOPSWITCH_PLUGIN)
+    list(APPEND STATIC_PLUGINS "desktopswitch")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Desktop Switcher")
     add_subdirectory(plugin-desktopswitch)
 endif()
@@ -121,6 +122,7 @@ endif(KBINDICATOR_PLUGIN)
 
 setByDefault(MAINMENU_PLUGIN Yes)
 if(MAINMENU_PLUGIN)
+    list(APPEND STATIC_PLUGINS "mainmenu")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Application menu")
     add_subdirectory(plugin-mainmenu)
 endif()
@@ -137,6 +139,7 @@ endif(MOUNT_PLUGIN)
 
 setByDefault(QUICKLAUNCH_PLUGIN Yes)
 if(QUICKLAUNCH_PLUGIN)
+    list(APPEND STATIC_PLUGINS "quicklaunch")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Quicklaunch")
     add_subdirectory(plugin-quicklaunch)
 endif()
@@ -163,6 +166,7 @@ endif()
 
 setByDefault(SHOWDESKTOP_PLUGIN Yes)
 if(SHOWDESKTOP_PLUGIN)
+    list(APPEND STATIC_PLUGINS "showdesktop")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Show Desktop")
     add_subdirectory(plugin-showdesktop)
 endif()
@@ -189,12 +193,14 @@ endif(SYSSTAT_PLUGIN)
 
 setByDefault(TASKBAR_PLUGIN Yes)
 if(TASKBAR_PLUGIN)
+  list(APPEND STATIC_PLUGINS "taskbar")
   set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "Taskbar")
   add_subdirectory(plugin-taskbar)
 endif()
 
 setByDefault(TRAY_PLUGIN Yes)
 if(TRAY_PLUGIN)
+    list(APPEND STATIC_PLUGINS "tray")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "System Tray")
     add_subdirectory(plugin-tray)
 endif()
@@ -230,6 +236,7 @@ endif()
 
 setByDefault(WORLDCLOCK_PLUGIN Yes)
 if(WORLDCLOCK_PLUGIN)
+    list(APPEND STATIC_PLUGINS "worldclock")
     set(ENABLED_PLUGINS ${ENABLED_PLUGINS} "World Clock")
     add_subdirectory(plugin-worldclock)
 endif(WORLDCLOCK_PLUGIN)
@@ -241,6 +248,8 @@ foreach (PLUGIN_STR ${ENABLED_PLUGINS})
     message(STATUS "  ${PLUGIN_STR}")
 endforeach()
 message(STATUS "*********************************************************************")
+
+add_subdirectory(panel)
 
 # building tarball with CPack -------------------------------------------------
 include(InstallRequiredSystemLibraries)

--- a/cmake/BuildPlugin.cmake
+++ b/cmake/BuildPlugin.cmake
@@ -44,10 +44,16 @@ MACRO (BUILD_LXQT_PLUGIN NAME)
         set(QTX_LIBRARIES ${QTX_LIBRARIES} Qt5::DBus)
     endif()
 
-    add_library(${NAME} MODULE ${HEADERS} ${SOURCES} ${MOC_SOURCES} ${${PROJECT_NAME}_QM_FILES} ${QRC_SOURCES} ${UIS} ${DESKTOP_FILES})
+    list(FIND STATIC_PLUGINS ${NAME} IS_STATIC)
+    set(SRC ${HEADERS} ${SOURCES} ${MOC_SOURCES} ${${PROJECT_NAME}_QM_FILES} ${QRC_SOURCES} ${UIS} ${DESKTOP_FILES})
+    if (${IS_STATIC} EQUAL -1) # not static
+        add_library(${NAME} MODULE ${SRC}) # build dynamically loadable modules
+        install(TARGETS ${NAME} DESTINATION ${PLUGIN_DIR}) # install the *.so file
+    else() # static
+        add_library(${NAME} STATIC ${SRC}) # build statically linked lib
+    endif()
     target_link_libraries(${NAME} ${QTX_LIBRARIES} ${LXQT_LIBRARIES} ${LIBRARIES} KF5::WindowSystem)
 
-    install(TARGETS ${NAME} DESTINATION ${PLUGIN_DIR})
     install(FILES ${CONFIG_FILES}  DESTINATION ${PLUGIN_SHARE_DIR})
     install(FILES ${DESKTOP_FILES} DESTINATION ${PROG_SHARE_DIR})
 

--- a/panel/CMakeLists.txt
+++ b/panel/CMakeLists.txt
@@ -93,7 +93,7 @@ lxqt_app_translation_loader(QM_LOADER ${PROJECT_NAME})
 
 
 add_executable(${PROJECT} ${lxqt-panel_PUB_H_FILES} ${lxqt-panel_PRIV_H_FILES} ${lxqt-panel_CPP_FILES} ${MOC_SOURCES} ${lxqt-runner_QM_FILES} ${QRC_SOURCES} ${UI_HEADERS} ${QM_LOADER})
-target_link_libraries(${PROJECT} ${LIBRARIES} ${QTX_LIBRARIES} KF5::WindowSystem)
+target_link_libraries(${PROJECT} ${LIBRARIES} ${QTX_LIBRARIES} KF5::WindowSystem ${STATIC_PLUGINS})
 
 install(TARGETS ${PROJECT} RUNTIME DESTINATION bin)
 install(FILES ${CONFIG_FILES} DESTINATION ${LXQT_ETC_XDG_DIR}/lxqt)

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -46,6 +46,17 @@
 #include <LXQt/Settings>
 #include <LXQt/Translator>
 #include <XdgIcon>
+#include <algorithm> // for std::lower_bound()
+
+// statically linked built-in plugins
+#include "../plugin-clock/lxqtclock.h" // clock
+#include "../plugin-desktopswitch/desktopswitch.h" // desktopswitch
+#include "../plugin-mainmenu/lxqtmainmenu.h" // mainmenu
+#include "../plugin-quicklaunch/lxqtquicklaunchplugin.h" // quicklaunch
+#include "../plugin-showdesktop/showdesktop.h" // showdesktop
+#include "../plugin-taskbar/lxqttaskbarplugin.h" // taskbar
+#include "../plugin-tray/lxqttrayplugin.h" // tray
+#include "../plugin-worldclock/lxqtworldclock.h" // worldclock
 
 QColor Plugin::mMoveMarkerColor= QColor(255, 0, 0, 255);
 
@@ -76,24 +87,32 @@ Plugin::Plugin(const LxQt::PluginInfo &desktopFile, const QString &settingsFile,
     dirs << QProcessEnvironment::systemEnvironment().value("LXQTPANEL_PLUGIN_PATH").split(":");
     dirs << PLUGIN_DIR;
 
-    QString baseName = QString("lib%1.so").arg(desktopFile.id());
     bool found = false;
-    foreach(QString dirName, dirs)
+    if(ILxQtPanelPluginLibrary* pluginLib = findStaticPlugin(desktopFile.id()))
     {
-        QFileInfo fi(QDir(dirName), baseName);
-
-        if (fi.exists())
+        // this is a static plugin
+        found = true;
+        loadLib(pluginLib);
+    }
+    else {
+        // this plugin is a dynamically loadable module
+        QString baseName = QString("lib%1.so").arg(desktopFile.id());
+        foreach(QString dirName, dirs)
         {
-            found = true;
-            if (loadLib(fi.absoluteFilePath()))
-                break;
+            QFileInfo fi(QDir(dirName), baseName);
+            if (fi.exists())
+            {
+                found = true;
+                if (loadModule(fi.absoluteFilePath()))
+                    break;
+            }
         }
     }
 
     if (!isLoaded())
     {
         if (!found)
-            qWarning() << QString("Plugin %1 not found in the").arg(baseName) << dirs;
+            qWarning() << QString("Plugin %1 not found in the").arg(desktopFile.id()) << dirs;
 
         return;
     }
@@ -156,7 +175,79 @@ void Plugin::setAlignment(Plugin::Alignment alignment)
 /************************************************
 
  ************************************************/
-bool Plugin::loadLib(const QString &libraryName)
+
+ILxQtPanelPluginLibrary* Plugin::findStaticPlugin(const QString &libraryName)
+{
+    // find a static plugin library by name
+    // internally this is implemented using binary search
+    // statically linked built-in plugins
+    static LxQtClockPluginLibrary clock_lib; // clock
+    static DesktopSwitchPluginLibrary desktopswitch_lib; // desktopswitch
+    static LxQtMainMenuPluginLibrary mainmenu_lib; // mainmenu
+    static LxQtQuickLaunchPluginLibrary quicklaunch_lib; // quicklaunch
+    static ShowDesktopLibrary showdesktop_lib; //showdesktop
+    static LxQtTaskBarPluginLibrary taskbar_lib; //taskbar
+    static LxQtTrayPluginLibrary tray_lib; //tray
+    static LxQtWorldClockLibrary worldclock_lib; // worldclock
+
+    static const QString names[] = // the names should be kept sorted (for binary search)
+    {
+        QStringLiteral("clock"),
+        QStringLiteral("desktopswitch"),
+        QStringLiteral("mainmenu"),
+        QStringLiteral("quicklaunch"),
+        QStringLiteral("showdesktop"),
+        QStringLiteral("taskbar"),
+        QStringLiteral("tray"),
+        QStringLiteral("worldclock")
+    };
+    static ILxQtPanelPluginLibrary* staticPlugins[] = // should be kept in the same order as names
+    {
+        &clock_lib,
+        &desktopswitch_lib,
+        &mainmenu_lib,
+        &quicklaunch_lib,
+        &showdesktop_lib,
+        &taskbar_lib,
+        &tray_lib,
+        &worldclock_lib
+    };
+
+    // for small tables, binary search is often faster than hash tables
+    const QString* end = names + sizeof(names)/sizeof(QString);
+    const QString* it = std::lower_bound(names, end, libraryName);
+    if(it != end && *it == libraryName) {
+        return staticPlugins[(it - names)];
+    }
+    return NULL;
+}
+
+// load a plugin from a library
+bool Plugin::loadLib(ILxQtPanelPluginLibrary* pluginLib)
+{
+    ILxQtPanelPluginStartupInfo startupInfo;
+    startupInfo.settings = mSettings;
+    startupInfo.desktopFile = &mDesktopFile;
+    startupInfo.lxqtPanel = mPanel;
+
+    mPlugin = pluginLib->instance(startupInfo);
+    if (!mPlugin)
+    {
+        qWarning() << QString("Can't load plugin \"%1\". Plugin can't build ILxQtPanelPlugin.").arg(mPluginLoader->fileName());
+        return false;
+    }
+
+    mPluginWidget = mPlugin->widget();
+    if (mPluginWidget)
+    {
+        mPluginWidget->setObjectName(mPlugin->themeId());
+    }
+    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    return true;
+}
+
+// load dynamic plugin from a *.so module
+bool Plugin::loadModule(const QString &libraryName)
 {
     mPluginLoader = new QPluginLoader(libraryName);
 
@@ -180,28 +271,7 @@ bool Plugin::loadLib(const QString &libraryName)
         delete obj;
         return false;
     }
-
-    ILxQtPanelPluginStartupInfo startupInfo;
-    startupInfo.settings = mSettings;
-    startupInfo.desktopFile = &mDesktopFile;
-    startupInfo.lxqtPanel = mPanel;
-
-    mPlugin = pluginLib->instance(startupInfo);
-    if (!mPlugin)
-    {
-        qWarning() << QString("Can't load plugin \"%1\". Plugin can't build ILxQtPanelPlugin.").arg(mPluginLoader->fileName());
-        delete obj;
-        return false;
-    }
-
-    mPluginWidget = mPlugin->widget();
-    if (mPluginWidget)
-    {
-        mPluginWidget->setObjectName(mPlugin->themeId());
-    }
-    this->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-    return true;
+    return loadLib(pluginLib);
 }
 
 

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -96,7 +96,9 @@ protected:
     void showEvent(QShowEvent *event);
 
 private:
-    bool loadLib(const QString &libraryName);
+    bool loadLib(ILxQtPanelPluginLibrary* pluginLib);
+    bool loadModule(const QString &libraryName);
+    ILxQtPanelPluginLibrary* findStaticPlugin(const QString &libraryName);
 
     const LxQt::PluginInfo mDesktopFile;
     QByteArray calcSettingsHash();

--- a/plugin-clock/lxqtclock.h
+++ b/plugin-clock/lxqtclock.h
@@ -95,7 +95,7 @@ private slots:
 class LxQtClockPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtClock(startupInfo);}

--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -83,7 +83,7 @@ private slots:
 class DesktopSwitchPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new DesktopSwitch(startupInfo);}

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -111,7 +111,7 @@ private slots:
 class LxQtMainMenuPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtMainMenu(startupInfo);}

--- a/plugin-quicklaunch/lxqtquicklaunchplugin.h
+++ b/plugin-quicklaunch/lxqtquicklaunchplugin.h
@@ -55,7 +55,7 @@ private:
 class LxQtQuickLaunchPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)

--- a/plugin-showdesktop/CMakeLists.txt
+++ b/plugin-showdesktop/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(PLUGIN "showdesktop")
 
+# Because of a bug in KWindowSystem, we still rely on a XCB function in this plugin
+# Later when KWindowSystem is fixed, we can drop xcb dependency
+find_package(PkgConfig)
+pkg_check_modules(XCB REQUIRED xcb)
+
 set(HEADERS
     showdesktop.h
 )
@@ -16,6 +21,7 @@ set(LIBRARIES
     ${LIBRARIES}
     ${LXQT_GLOBALKEYS_LIBRARIES}
     ${QTXDG_LIBRARIES}
+    ${XCB_LIBRARIES}
 )
 
 BUILD_LXQT_PLUGIN(${PLUGIN})

--- a/plugin-showdesktop/showdesktop.h
+++ b/plugin-showdesktop/showdesktop.h
@@ -60,7 +60,7 @@ private:
 class ShowDesktopLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)

--- a/plugin-taskbar/lxqttaskbarplugin.h
+++ b/plugin-taskbar/lxqttaskbarplugin.h
@@ -60,7 +60,7 @@ private:
 class LxQtTaskBarPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtTaskBarPlugin(startupInfo);}

--- a/plugin-tray/CMakeLists.txt
+++ b/plugin-tray/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(PLUGIN "tray")
 
-include(FindPkgConfig)
 include(CheckLibraryExists)
+
+find_package(PkgConfig)
+pkg_check_modules(XCB REQUIRED xcb)
+pkg_check_modules(XCB_DAMAGE REQUIRED xcb-damage)
 
 find_package(X11 REQUIRED)
 pkg_check_modules(XCOMPOSITE REQUIRED xcomposite)

--- a/plugin-tray/lxqttrayplugin.h
+++ b/plugin-tray/lxqttrayplugin.h
@@ -55,7 +55,7 @@ private:
 class LxQtTrayPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
 {
     Q_OBJECT
-    Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
+    // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
     ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)


### PR DESCRIPTION
Make some frequently used plugins "statically-linked" to speed up plugin loading.
The static plugins are: clock, desktopswitch, mainmenu, quicklaunch, showdesktop, taskbar, tray, and worldclock.
They'll be statically linked into lxqt-panel and have no *.so modules.
Binary search is used internally for plugin name matching.
This is a relatively larger change so I hope more developers can help the review.
Only few lines of source code are changed, though.
@luis-pereira, @paulolieuthier @jleclanche @kuzmas @surlykke @agaida 
Thanks!