### PR TITLE
plugin-mount: Use only one icon instead a list of possible ones

### DIFF
--- a/plugin-mount/mountbutton.cpp
+++ b/plugin-mount/mountbutton.cpp
@@ -33,7 +33,7 @@
 MountButton::MountButton(QWidget * parent) :
     QToolButton(parent)
 {
-    setIcon(XdgIcon::fromTheme(QStringList() << "device-notifier" << "drive-removable-media-usb" << "drive-removable-media"));
+    setIcon(XdgIcon::fromTheme(QStringLiteral("drive-removable-media")));
 
     setToolTip(tr("Removable media/devices manager"));
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);


### PR DESCRIPTION
Using more than one icon can lead to icons not being show, depending on the
theme set when XdgIcon::fromTheme() is executed, although it may exits on
the theme.
QIconloaderEngine only stores the icon it founded when XdgIcon::fromTheme()
was executed. When the theme changes QIconLoader will only search for the
icon name it stored when XdgIcon::fromTheme() was executed.