### PR TITLE
plugin-quicklaunch: handle submenus

### DIFF
--- a/plugin-quicklaunch/quicklaunchaction.h
+++ b/plugin-quicklaunch/quicklaunchaction.h
@@ -44,6 +44,8 @@ class QuickLaunchAction : public QAction
     Q_OBJECT
 
 public:
+    enum ActionType { ActionLegacy, ActionXdg, ActionXdgDirectory, ActionFile };
+
     /*! Constructor for "legacy" launchers.
         \warning The XDG way is preferred this is only for older or non-standard apps
         \param name a name to display in tooltip
@@ -57,6 +59,7 @@ public:
     /*! Constructor for XDG desktop handlers.
      */
     QuickLaunchAction(const XdgDesktopFile * xdg, QWidget * parent);
+
     /*! Constructor for regular files
      */
     QuickLaunchAction(const QString & fileName, QWidget * parent);
@@ -64,17 +67,25 @@ public:
     //! Returns true if the action is valid (contains all required properties).
     bool isValid() { return m_valid; }
 
+    //! Returns the type of the action
+    ActionType type() { return m_type; }
+
+    //! Returns the "subactions" of this action if it's type is ActionXdgDirectory
+    QList<QuickLaunchAction*> subActions() { return m_subActions; }
+
     QHash<QString, QString> settingsMap() { return m_settingsMap; }
 
 public slots:
     void execAction();
 
 private:
-    enum ActionType { ActionLegacy, ActionXdg, ActionFile };
     ActionType m_type;
     QString m_data;
     bool m_valid;
     QHash<QString, QString> m_settingsMap;
+
+    // For directories
+    QList<QuickLaunchAction*> m_subActions;
 };
 
 #endif

--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -41,14 +41,14 @@
 
 QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, QWidget * parent)
     : QToolButton(parent),
-      mAct(act)
+      mAct(act),
+      mDirectoryMenu(new QMenu(this)),
+      mContextMenu(new QMenu(this))
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAcceptDrops(true);
 
-    setDefaultAction(mAct);
     mAct->setParent(this);
-
     mMoveLeftAct = new QAction(XdgIcon::fromTheme("go-previous"), tr("Move left"), this);
     connect(mMoveLeftAct, SIGNAL(triggered()), this, SIGNAL(movedLeft()));
 
@@ -59,13 +59,29 @@ QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, QWidget * parent)
     mDeleteAct = new QAction(XdgIcon::fromTheme("dialog-close"), tr("Remove from quicklaunch"), this);
     connect(mDeleteAct, SIGNAL(triggered()), this, SLOT(selfRemove()));
     addAction(mDeleteAct);
-    mMenu = new QMenu(this);
-    mMenu->addAction(mAct);
-    mMenu->addSeparator();
-    mMenu->addAction(mMoveLeftAct);
-    mMenu->addAction(mMoveRightAct);
-    mMenu->addSeparator();
-    mMenu->addAction(mDeleteAct);
+
+    if (mAct->type() == QuickLaunchAction::ActionXdgDirectory)
+    {
+        setIcon(mAct->icon());
+        connect(this, SIGNAL(clicked(bool)), this, SLOT(onClicked()));
+        foreach (QuickLaunchAction *action, mAct->subActions())
+        {
+            QAction *qaction = qobject_cast<QAction*>(action);
+            mDirectoryMenu->addAction(qaction);
+            mContextMenu->addAction(qaction);
+        }
+    }
+    else
+    {
+        setDefaultAction(mAct);
+        mContextMenu->addAction(mAct);
+    }
+
+    mContextMenu->addSeparator();
+    mContextMenu->addAction(mMoveLeftAct);
+    mContextMenu->addAction(mMoveRightAct);
+    mContextMenu->addSeparator();
+    mContextMenu->addAction(mDeleteAct);
 
 
     setContextMenuPolicy(Qt::CustomContextMenu);
@@ -91,11 +107,15 @@ void QuickLaunchButton::this_customContextMenuRequested(const QPoint & pos)
 {
     LxQtQuickLaunch *panel = qobject_cast<LxQtQuickLaunch*>(parent());
 
-    mMoveLeftAct->setEnabled( panel && panel->indexOfButton(this) > 0);
+    mMoveLeftAct->setEnabled(panel && panel->indexOfButton(this) > 0);
     mMoveRightAct->setEnabled(panel && panel->indexOfButton(this) < panel->countOfButtons() - 1);
-    mMenu->popup(mapToGlobal(pos));
+    mContextMenu->popup(mapToGlobal(pos));
 }
 
+void QuickLaunchButton::onClicked()
+{
+    mDirectoryMenu->exec(QCursor::pos());
+}
 
 void QuickLaunchButton::selfRemove()
 {

--- a/plugin-quicklaunch/quicklaunchbutton.h
+++ b/plugin-quicklaunch/quicklaunchbutton.h
@@ -64,12 +64,14 @@ private:
     QAction *mDeleteAct;
     QAction *mMoveLeftAct;
     QAction *mMoveRightAct;
-    QMenu *mMenu;
+    QMenu *mDirectoryMenu; // only used for QuickLaunchAction of ActionType ActionXdgDirectory
+    QMenu *mContextMenu;
     QPoint mDragStart;
 
 private slots:
     void this_customContextMenuRequested(const QPoint & pos);
     void selfRemove();
+    void onClicked(); // only used for XdgDesktopFile of ActionType ActionXdgDirectory
 };
 
 


### PR DESCRIPTION
Show a menu with the submenu's items (submenus dragged from the panel's main menu, for example).

Depends on lxde/libqtxdg#49. Fixes the first issue described in lxde/lxqt#98 and fixes lxde/lxqt#477 (although it's not the best way to fix it).