### PR TITLE
Shows windows from current screen only option 

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -118,9 +118,6 @@ bool LxQtTaskBar::windowOnCurrentScreen(WId window) const
     if (desktop == NET::OnAllDesktops)
         return true;
 
-    if (desktop != KWindowSystem::currentDesktop())
-        return false;
-
     QDesktopWidget desc;
     QRect frame = info.frameGeometry();
     QPoint midpoint = (frame.topLeft() + frame.bottomRight()) / 2;

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -83,10 +83,12 @@ private:
     LxQtTaskButton* mCheckedBtn;
     bool mCloseOnMiddleClick;
     bool mShowOnlyCurrentDesktopTasks;
+    bool mShowOnlyCurrentScreenTasks;
     bool mAutoRotate;
 
     LxQtTaskButton* buttonByWindow(WId window) const;
     bool windowOnActiveDesktop(WId window) const;
+    bool windowOnCurrentScreen(WId window) const;
     bool acceptWindow(WId window) const;
     void setButtonStyle(Qt::ToolButtonStyle buttonStyle);
 

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -50,14 +50,13 @@ LxQtTaskbarConfiguration::LxQtTaskbarConfiguration(QSettings &settings, QWidget 
     loadSettings();
     /* We use clicked() and activated(int) because these signals aren't emitting after programmaticaly
         change of state */
-    connect(ui->fAllDesktopsCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->fCurrentDesktopRB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->limitByDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->limitByScreenCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->buttonStyleCB, SIGNAL(activated(int)), this, SLOT(updateControls(int)));
     connect(ui->buttonStyleCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
     connect(ui->buttonWidthSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     connect(ui->autoRotateCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->middleClickCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
-    connect(ui->fCurrentScreenRB, SIGNAL(clicked()), this, SLOT(saveSettings()));
 }
 
 LxQtTaskbarConfiguration::~LxQtTaskbarConfiguration()
@@ -67,18 +66,8 @@ LxQtTaskbarConfiguration::~LxQtTaskbarConfiguration()
 
 void LxQtTaskbarConfiguration::loadSettings()
 {
-    if (mSettings.value("showOnlyCurrentDesktopTasks", false).toBool() == true)
-    {
-        ui->fCurrentDesktopRB->setChecked(true);
-    }
-    else if (mSettings.value("showOnlyCurrentScreenTasks", false).toBool() == true)
-    {
-        ui->fCurrentScreenRB->setChecked(true);
-    }
-    else
-    {
-        ui->fAllDesktopsCB->setChecked(true);
-    }
+    ui->limitByDesktopCB->setChecked(mSettings.value("showOnlyCurrentDesktopTasks", false).toBool());
+    ui->limitByScreenCB->setChecked(mSettings.value("showOnlyCurrentScreenTasks", false).toBool());
 
     ui->autoRotateCB->setChecked(mSettings.value("autoRotate", true).toBool());
     ui->middleClickCB->setChecked(mSettings.value("closeOnMiddleClick", true).toBool());
@@ -91,8 +80,8 @@ void LxQtTaskbarConfiguration::loadSettings()
 
 void LxQtTaskbarConfiguration::saveSettings()
 {
-    mSettings.setValue("showOnlyCurrentDesktopTasks", ui->fCurrentDesktopRB->isChecked());
-    mSettings.setValue("showOnlyCurrentScreenTasks", ui->fCurrentScreenRB->isChecked());
+    mSettings.setValue("showOnlyCurrentDesktopTasks", ui->limitByDesktopCB->isChecked());
+    mSettings.setValue("showOnlyCurrentScreenTasks", ui->limitByScreenCB->isChecked());
     mSettings.setValue("buttonStyle", ui->buttonStyleCB->itemData(ui->buttonStyleCB->currentIndex()));
     mSettings.setValue("buttonWidth", ui->buttonWidthSB->value());
     mSettings.setValue("autoRotate", ui->autoRotateCB->isChecked());

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -57,6 +57,7 @@ LxQtTaskbarConfiguration::LxQtTaskbarConfiguration(QSettings &settings, QWidget 
     connect(ui->buttonWidthSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     connect(ui->autoRotateCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->middleClickCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->fCurrentScreenRB, SIGNAL(clicked()), this, SLOT(saveSettings()));
 }
 
 LxQtTaskbarConfiguration::~LxQtTaskbarConfiguration()
@@ -69,6 +70,10 @@ void LxQtTaskbarConfiguration::loadSettings()
     if (mSettings.value("showOnlyCurrentDesktopTasks", false).toBool() == true)
     {
         ui->fCurrentDesktopRB->setChecked(true);
+    }
+    else if (mSettings.value("showOnlyCurrentScreenTasks", false).toBool() == true)
+    {
+        ui->fCurrentScreenRB->setChecked(true);
     }
     else
     {
@@ -87,6 +92,7 @@ void LxQtTaskbarConfiguration::loadSettings()
 void LxQtTaskbarConfiguration::saveSettings()
 {
     mSettings.setValue("showOnlyCurrentDesktopTasks", ui->fCurrentDesktopRB->isChecked());
+    mSettings.setValue("showOnlyCurrentScreenTasks", ui->fCurrentScreenRB->isChecked());
     mSettings.setValue("buttonStyle", ui->buttonStyleCB->itemData(ui->buttonStyleCB->currentIndex()));
     mSettings.setValue("buttonWidth", ui->buttonWidthSB->value());
     mSettings.setValue("autoRotate", ui->autoRotateCB->isChecked());

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -40,6 +40,16 @@
         </attribute>
        </widget>
       </item>
+      <item>
+       <widget class="QRadioButton" name="fCurrentScreenRB">
+        <property name="text">
+         <string>Show windows from current screen</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">wlcB</string>
+        </attribute>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>354</width>
-    <height>316</height>
+    <height>325</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,33 +21,17 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QRadioButton" name="fCurrentDesktopRB">
+       <widget class="QCheckBox" name="limitByDesktopCB">
         <property name="text">
-         <string>Show windows from current desktop</string>
+         <string>Limit by current desktop</string>
         </property>
-        <attribute name="buttonGroup">
-         <string notr="true">wlcB</string>
-        </attribute>
        </widget>
       </item>
       <item>
-       <widget class="QRadioButton" name="fAllDesktopsCB">
+       <widget class="QCheckBox" name="limitByScreenCB">
         <property name="text">
-         <string>Show windows from all desktops</string>
+         <string>Limit by current screen</string>
         </property>
-        <attribute name="buttonGroup">
-         <string notr="true">wlcB</string>
-        </attribute>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="fCurrentScreenRB">
-        <property name="text">
-         <string>Show windows from current screen</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">wlcB</string>
-        </attribute>
        </widget>
       </item>
      </layout>
@@ -169,7 +153,4 @@
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="wlcB"/>
- </buttongroups>
 </ui>


### PR DESCRIPTION
Shows windows in taskbar for current screen only. It's mostly the same as desktop only, but additionaly filters windows by taskbar's screen (monitor)