### PR TITLE
Static plugin names&objects initialized on one place

### DIFF
--- a/panel/ilxqtpanelplugin.h
+++ b/panel/ilxqtpanelplugin.h
@@ -220,7 +220,7 @@ public:
     /**
     Returns the root component object of the plugin. When the library is finally unloaded, the root component will automatically be deleted.
      **/
-    virtual ILxQtPanelPlugin* instance(const ILxQtPanelPluginStartupInfo &startupInfo) = 0;
+    virtual ILxQtPanelPlugin* instance(const ILxQtPanelPluginStartupInfo &startupInfo) const = 0;
 };
 
 

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -88,7 +88,7 @@ Plugin::Plugin(const LxQt::PluginInfo &desktopFile, const QString &settingsFile,
     dirs << PLUGIN_DIR;
 
     bool found = false;
-    if(ILxQtPanelPluginLibrary* pluginLib = findStaticPlugin(desktopFile.id()))
+    if(ILxQtPanelPluginLibrary const * pluginLib = findStaticPlugin(desktopFile.id()))
     {
         // this is a static plugin
         found = true;
@@ -176,7 +176,7 @@ void Plugin::setAlignment(Plugin::Alignment alignment)
 
  ************************************************/
 
-ILxQtPanelPluginLibrary* Plugin::findStaticPlugin(const QString &libraryName)
+ILxQtPanelPluginLibrary const * Plugin::findStaticPlugin(const QString &libraryName)
 {
     // find a static plugin library by name
     // internally this is implemented using binary search
@@ -280,7 +280,7 @@ ILxQtPanelPluginLibrary* Plugin::findStaticPlugin(const QString &libraryName)
 }
 
 // load a plugin from a library
-bool Plugin::loadLib(ILxQtPanelPluginLibrary* pluginLib)
+bool Plugin::loadLib(ILxQtPanelPluginLibrary const * pluginLib)
 {
     ILxQtPanelPluginStartupInfo startupInfo;
     startupInfo.settings = mSettings;

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -96,9 +96,9 @@ protected:
     void showEvent(QShowEvent *event);
 
 private:
-    bool loadLib(ILxQtPanelPluginLibrary* pluginLib);
+    bool loadLib(ILxQtPanelPluginLibrary const * pluginLib);
     bool loadModule(const QString &libraryName);
-    ILxQtPanelPluginLibrary* findStaticPlugin(const QString &libraryName);
+    ILxQtPanelPluginLibrary const * findStaticPlugin(const QString &libraryName);
 
     const LxQt::PluginInfo mDesktopFile;
     QByteArray calcSettingsHash();

--- a/plugin-clock/lxqtclock.h
+++ b/plugin-clock/lxqtclock.h
@@ -98,7 +98,7 @@ class LxQtClockPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtClock(startupInfo);}
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const { return new LxQtClock(startupInfo);}
 };
 
 

--- a/plugin-colorpicker/colorpicker.h
+++ b/plugin-colorpicker/colorpicker.h
@@ -86,7 +86,7 @@ class ColorPickerLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new ColorPicker(startupInfo);
     }

--- a/plugin-cpuload/lxqtcpuloadplugin.h
+++ b/plugin-cpuload/lxqtcpuloadplugin.h
@@ -63,7 +63,7 @@ class LxQtCpuLoadPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtCpuLoadPlugin(startupInfo);
     }

--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -97,7 +97,7 @@ class DesktopSwitchPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new DesktopSwitch(startupInfo);}
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const { return new DesktopSwitch(startupInfo);}
 };
 
 #endif

--- a/plugin-dom/domplugin.h
+++ b/plugin-dom/domplugin.h
@@ -57,7 +57,7 @@ class DomPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new DomPlugin(startupInfo);
     }

--- a/plugin-kbindicator/lxqtkbindicator.h
+++ b/plugin-kbindicator/lxqtkbindicator.h
@@ -74,7 +74,7 @@ class LxQtKbIndicatorLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtKbIndicator(startupInfo);
     }

--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -115,7 +115,7 @@ class LxQtMainMenuPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtMainMenu(startupInfo);}
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const { return new LxQtMainMenu(startupInfo);}
 };
 
 #endif

--- a/plugin-mount/lxqtmountplugin.h
+++ b/plugin-mount/lxqtmountplugin.h
@@ -79,7 +79,7 @@ class LxQtMountPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtMountPlugin(startupInfo);
     }

--- a/plugin-networkmonitor/lxqtnetworkmonitorplugin.h
+++ b/plugin-networkmonitor/lxqtnetworkmonitorplugin.h
@@ -62,7 +62,7 @@ class LxQtNetworkMonitorPluginLibrary: public QObject, public ILxQtPanelPluginLi
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtNetworkMonitorPlugin(startupInfo);
     }

--- a/plugin-quicklaunch/lxqtquicklaunchplugin.h
+++ b/plugin-quicklaunch/lxqtquicklaunchplugin.h
@@ -59,7 +59,7 @@ class LxQtQuickLaunchPluginLibrary: public QObject, public ILxQtPanelPluginLibra
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtQuickLaunchPlugin(startupInfo);
     }

--- a/plugin-screensaver/panelscreensaver.h
+++ b/plugin-screensaver/panelscreensaver.h
@@ -62,7 +62,7 @@ class PanelScreenSaverLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new PanelScreenSaver(startupInfo);
     }

--- a/plugin-sensors/lxqtsensorsplugin.h
+++ b/plugin-sensors/lxqtsensorsplugin.h
@@ -65,7 +65,7 @@ class LxQtSensorsPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtSensorsPlugin(startupInfo);
     }

--- a/plugin-showdesktop/showdesktop.h
+++ b/plugin-showdesktop/showdesktop.h
@@ -63,7 +63,7 @@ class ShowDesktopLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new ShowDesktop(startupInfo);
     }

--- a/plugin-spacer/spacer.h
+++ b/plugin-spacer/spacer.h
@@ -84,7 +84,7 @@ class SpacerPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new Spacer(startupInfo);}
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const { return new Spacer(startupInfo);}
 };
 
 #endif

--- a/plugin-statusnotifier/statusnotifier.h
+++ b/plugin-statusnotifier/statusnotifier.h
@@ -53,7 +53,7 @@ class StatusNotifierLibrary : public QObject, public ILxQtPanelPluginLibrary
 //     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new StatusNotifier(startupInfo);
     }

--- a/plugin-sysstat/lxqtsysstat.h
+++ b/plugin-sysstat/lxqtsysstat.h
@@ -217,7 +217,7 @@ class LxQtSysStatLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtSysStat(startupInfo);
     }

--- a/plugin-taskbar/lxqttaskbarplugin.h
+++ b/plugin-taskbar/lxqttaskbarplugin.h
@@ -63,7 +63,7 @@ class LxQtTaskBarPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) { return new LxQtTaskBarPlugin(startupInfo);}
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const { return new LxQtTaskBarPlugin(startupInfo);}
 };
 
 #endif // LXQTTASKBARPLUGIN_H

--- a/plugin-tray/lxqttrayplugin.h
+++ b/plugin-tray/lxqttrayplugin.h
@@ -58,7 +58,7 @@ class LxQtTrayPluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     // Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtTrayPlugin(startupInfo);
     }

--- a/plugin-volume/lxqtvolume.h
+++ b/plugin-volume/lxqtvolume.h
@@ -86,7 +86,7 @@ class LxQtVolumePluginLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtVolume(startupInfo);
     }

--- a/plugin-worldclock/lxqtworldclock.h
+++ b/plugin-worldclock/lxqtworldclock.h
@@ -135,7 +135,7 @@ class LxQtWorldClockLibrary: public QObject, public ILxQtPanelPluginLibrary
     Q_PLUGIN_METADATA(IID "lxde-qt.org/Panel/PluginInterface/3.0")
     Q_INTERFACES(ILxQtPanelPluginLibrary)
 public:
-    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo)
+    ILxQtPanelPlugin *instance(const ILxQtPanelPluginStartupInfo &startupInfo) const
     {
         return new LxQtWorldClock(startupInfo);
     }


### PR DESCRIPTION
While adding the ```#ifdef```s I thought it will be better to have everything together and not on 3 different places. This way it seems to me much less error prone.

I think this new style should be as good as the previous from perfomance point of view. @PCMan what is your opinion on the efficiency/performance of the new style?