### PR TITLE
plugin-desktopswitch: Option to display names instead of numbers

### DIFF
--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -33,6 +33,8 @@
 #include <QFrame>
 #include <QScopedPointer>
 
+#include "desktopswitchbutton.h"
+
 class QSignalMapper;
 class QButtonGroup;
 class NETRootInfo;
@@ -80,6 +82,7 @@ private:
     LxQt::GridLayout *mLayout;
     int mRows;
     QScopedPointer<NETRootInfo> mDesktops;
+    DesktopSwitchButton::LabelType mLabelType;
 
     void setup();
 

--- a/plugin-desktopswitch/desktopswitchbutton.cpp
+++ b/plugin-desktopswitch/desktopswitchbutton.cpp
@@ -32,15 +32,22 @@
 
 #include "desktopswitchbutton.h"
 
-DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, const QString &title)
+DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType,  const QString &title)
     : QToolButton(parent)
     , m_shortcut(0)
     , mIndex(index)
 {
-    setText(QString::number(index + 1));
+    switch (labelType) {
+        case LABEL_TYPE_NAME:
+            setText(title);
+            break;
+
+        default: // LABEL_TYPE_NUMBER
+            setText(QString::number(index + 1));
+    }
     setCheckable(true);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    
+
     if (!shortcut.isEmpty())
     {
         QString description = tr("Switch to desktop %1").arg(index + 1);
@@ -56,7 +63,7 @@ DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QStr
             connect(m_shortcut, SIGNAL(activated()), this, SIGNAL(activated()));
         }
     }
-    
+
     if (!title.isEmpty())
     {
         setToolTip(title);

--- a/plugin-desktopswitch/desktopswitchbutton.h
+++ b/plugin-desktopswitch/desktopswitchbutton.h
@@ -42,7 +42,12 @@ class DesktopSwitchButton : public QToolButton
     Q_OBJECT
     
 public:
-    DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, const QString &title=QString());
+    enum LabelType { // Must match with combobox indexes
+        LABEL_TYPE_NUMBER = 0,
+        LABEL_TYPE_NAME = 1
+    };
+
+    DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType, const QString &title=QString());
 
 public slots:
     void unregisterShortcut();

--- a/plugin-desktopswitch/desktopswitchconfiguration.cpp
+++ b/plugin-desktopswitch/desktopswitchconfiguration.cpp
@@ -43,6 +43,7 @@ DesktopSwitchConfiguration::DesktopSwitchConfiguration(QSettings *settings, QWid
     loadSettings();
 
     connect(ui->rowsSB, SIGNAL(valueChanged(int)), this, SLOT(rowsChanged(int)));
+    connect(ui->labelTypeCB, SIGNAL(currentIndexChanged(int)), this, SLOT(labelTypeChanged(int)));
 }
 
 DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
@@ -53,12 +54,18 @@ DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
 void DesktopSwitchConfiguration::loadSettings()
 {
     ui->rowsSB->setValue(mSettings->value("rows", 1).toInt());
+    ui->labelTypeCB->setCurrentIndex(mSettings->value("labelType", 0).toInt());
 
 }
 
 void DesktopSwitchConfiguration::rowsChanged(int value)
 {
     mSettings->setValue("rows", value);
+}
+
+void DesktopSwitchConfiguration::labelTypeChanged(int type)
+{
+    mSettings->setValue("labelType", type);
 }
 
 void DesktopSwitchConfiguration::dialogButtonsAction(QAbstractButton *btn)

--- a/plugin-desktopswitch/desktopswitchconfiguration.h
+++ b/plugin-desktopswitch/desktopswitchconfiguration.h
@@ -59,6 +59,7 @@ private slots:
     void loadSettings();
     void dialogButtonsAction(QAbstractButton *btn);
     void rowsChanged(int value);
+    void labelTypeChanged(int type);
 };
 
 #endif // DESKTOPSWITCHCERCONFIGURATION_H

--- a/plugin-desktopswitch/desktopswitchconfiguration.ui
+++ b/plugin-desktopswitch/desktopswitchconfiguration.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>DesktopSwitchConfiguration</class>
  <widget class="QDialog" name="DesktopSwitchConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>378</width>
+    <height>153</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>DesktopSwitch settings</string>
   </property>
@@ -26,7 +34,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Desktop labels:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -34,6 +49,20 @@
      <property name="standardButtons">
       <set>QDialogButtonBox::Close</set>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="labelTypeCB">
+     <item>
+      <property name="text">
+       <string>Numbers</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Names</string>
+      </property>
+     </item>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This PR has the behaviour described in lxde/lxqt#553.

Meaning that I have added a ~~checkbox~~ *combobox* option to change the desktop labels from numbers to names, and it works fine.

~~I have marked it as WIP since I would like to change the CheckBox for a ComboBox which would allow more options for the desktop labels (for example numbers as roman numerals) and would be clearer in the configuration window.~~