### PR TITLE
Add required package xcb-util to plugin-tray

### DIFF
--- a/plugin-tray/CMakeLists.txt
+++ b/plugin-tray/CMakeLists.txt
@@ -4,6 +4,7 @@ include(CheckLibraryExists)
 
 find_package(PkgConfig)
 pkg_check_modules(XCB REQUIRED xcb)
+pkg_check_modules(XCB_UTIL REQUIRED xcb-util)
 pkg_check_modules(XCB_DAMAGE REQUIRED xcb-damage)
 
 find_package(X11 REQUIRED)


### PR DESCRIPTION
Without this package, make will fail on plugin-tray/lxqttray.h because xcb/xcb_event.h is missing.

I have tried this on Ubuntu 14.10. I think this could be merged without any problems.