### PR TITLE
plugin-desktopswitch: refactoring and optimizations

### DIFF
--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -33,6 +33,8 @@
 #include <QFrame>
 #include <QScopedPointer>
 
+#include "desktopswitchbutton.h"
+
 class QSignalMapper;
 class QButtonGroup;
 class NETRootInfo;
@@ -80,6 +82,7 @@ private:
     LxQt::GridLayout *mLayout;
     int mRows;
     QScopedPointer<NETRootInfo> mDesktops;
+    DesktopSwitchButton::LabelType mLabelType;
 
     void setup();
 

--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -47,7 +47,7 @@ class DesktopSwitchWidget: public QFrame
     Q_OBJECT
 public:
     DesktopSwitchWidget();
-    
+
 private:
     int m_mouseWheelThresholdCounter;
 
@@ -77,14 +77,13 @@ private:
     QButtonGroup * m_buttons;
     QSignalMapper* m_pSignalMapper;
     int m_desktopCount;
-    QStringList m_desktopNames;
     DesktopSwitchWidget mWidget;
     LxQt::GridLayout *mLayout;
     int mRows;
     QScopedPointer<NETRootInfo> mDesktops;
     DesktopSwitchButton::LabelType mLabelType;
 
-    void setup();
+    void refresh();
 
 private slots:
     void setDesktop(int desktop);

--- a/plugin-desktopswitch/desktopswitchbutton.cpp
+++ b/plugin-desktopswitch/desktopswitchbutton.cpp
@@ -32,15 +32,22 @@
 
 #include "desktopswitchbutton.h"
 
-DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, const QString &title)
+DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType,  const QString &title)
     : QToolButton(parent)
     , m_shortcut(0)
     , mIndex(index)
 {
-    setText(QString::number(index + 1));
+    switch (labelType) {
+        case LABEL_TYPE_NAME:
+            setText(title);
+            break;
+
+        default: // LABEL_TYPE_NUMBER
+            setText(QString::number(index + 1));
+    }
     setCheckable(true);
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    
+
     if (!shortcut.isEmpty())
     {
         QString description = tr("Switch to desktop %1").arg(index + 1);
@@ -56,7 +63,7 @@ DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QStr
             connect(m_shortcut, SIGNAL(activated()), this, SIGNAL(activated()));
         }
     }
-    
+
     if (!title.isEmpty())
     {
         setToolTip(title);

--- a/plugin-desktopswitch/desktopswitchbutton.cpp
+++ b/plugin-desktopswitch/desktopswitchbutton.cpp
@@ -32,12 +32,19 @@
 
 #include "desktopswitchbutton.h"
 
-DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType,  const QString &title)
+DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, LabelType labelType,  const QString &title)
     : QToolButton(parent)
-    , m_shortcut(0)
-    , mIndex(index)
 {
-    switch (labelType) {
+    update(index, labelType, title);
+
+    setCheckable(true);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+}
+
+void DesktopSwitchButton::update(int index, LabelType labelType, const QString &title)
+{
+    switch (labelType)
+    {
         case LABEL_TYPE_NAME:
             setText(title);
             break;
@@ -45,32 +52,9 @@ DesktopSwitchButton::DesktopSwitchButton(QWidget * parent, int index, const QStr
         default: // LABEL_TYPE_NUMBER
             setText(QString::number(index + 1));
     }
-    setCheckable(true);
-    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-    if (!shortcut.isEmpty())
-    {
-        QString description = tr("Switch to desktop %1").arg(index + 1);
-        if (!title.isEmpty())
-        {
-            description.append(QString(" (%1)").arg(title));
-        }
-        m_shortcut = GlobalKeyShortcut::Client::instance()->addAction(QString(), path, description, this);
-        if (m_shortcut)
-        {
-            if (m_shortcut->shortcut().isEmpty())
-                m_shortcut->changeShortcut(shortcut);
-            connect(m_shortcut, SIGNAL(activated()), this, SIGNAL(activated()));
-        }
-    }
 
     if (!title.isEmpty())
     {
         setToolTip(title);
     }
-}
-
-void DesktopSwitchButton::unregisterShortcut()
-{
-    GlobalKeyShortcut::Client::instance()->removeAction(QString("/desktop_switch/desktop_%1").arg(mIndex + 1));
 }

--- a/plugin-desktopswitch/desktopswitchbutton.h
+++ b/plugin-desktopswitch/desktopswitchbutton.h
@@ -40,24 +40,15 @@ class Action;
 class DesktopSwitchButton : public QToolButton
 {
     Q_OBJECT
-    
+
 public:
     enum LabelType { // Must match with combobox indexes
         LABEL_TYPE_NUMBER = 0,
         LABEL_TYPE_NAME = 1
     };
 
-    DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType, const QString &title=QString());
-
-public slots:
-    void unregisterShortcut();
-
-signals:
-    void activated();
-
-private:
-    GlobalKeyShortcut::Action * m_shortcut;
-    int mIndex;
+    DesktopSwitchButton(QWidget * parent, int index, LabelType labelType, const QString &title=QString());
+    void update(int index, LabelType labelType,  const QString &title);
 };
 
 #endif

--- a/plugin-desktopswitch/desktopswitchbutton.h
+++ b/plugin-desktopswitch/desktopswitchbutton.h
@@ -42,7 +42,12 @@ class DesktopSwitchButton : public QToolButton
     Q_OBJECT
     
 public:
-    DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, const QString &title=QString());
+    enum LabelType { // Must match with combobox indexes
+        LABEL_TYPE_NUMBER = 0,
+        LABEL_TYPE_NAME = 1
+    };
+
+    DesktopSwitchButton(QWidget * parent, int index, const QString &path, const QString &shortcut, LabelType labelType, const QString &title=QString());
 
 public slots:
     void unregisterShortcut();

--- a/plugin-desktopswitch/desktopswitchconfiguration.cpp
+++ b/plugin-desktopswitch/desktopswitchconfiguration.cpp
@@ -43,6 +43,7 @@ DesktopSwitchConfiguration::DesktopSwitchConfiguration(QSettings *settings, QWid
     loadSettings();
 
     connect(ui->rowsSB, SIGNAL(valueChanged(int)), this, SLOT(rowsChanged(int)));
+    connect(ui->labelTypeCB, SIGNAL(currentIndexChanged(int)), this, SLOT(labelTypeChanged(int)));
 }
 
 DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
@@ -53,12 +54,18 @@ DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
 void DesktopSwitchConfiguration::loadSettings()
 {
     ui->rowsSB->setValue(mSettings->value("rows", 1).toInt());
+    ui->labelTypeCB->setCurrentIndex(mSettings->value("labelType", 0).toInt());
 
 }
 
 void DesktopSwitchConfiguration::rowsChanged(int value)
 {
     mSettings->setValue("rows", value);
+}
+
+void DesktopSwitchConfiguration::labelTypeChanged(int type)
+{
+    mSettings->setValue("labelType", type);
 }
 
 void DesktopSwitchConfiguration::dialogButtonsAction(QAbstractButton *btn)

--- a/plugin-desktopswitch/desktopswitchconfiguration.h
+++ b/plugin-desktopswitch/desktopswitchconfiguration.h
@@ -59,6 +59,7 @@ private slots:
     void loadSettings();
     void dialogButtonsAction(QAbstractButton *btn);
     void rowsChanged(int value);
+    void labelTypeChanged(int type);
 };
 
 #endif // DESKTOPSWITCHCERCONFIGURATION_H

--- a/plugin-desktopswitch/desktopswitchconfiguration.ui
+++ b/plugin-desktopswitch/desktopswitchconfiguration.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>DesktopSwitchConfiguration</class>
  <widget class="QDialog" name="DesktopSwitchConfiguration">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>378</width>
+    <height>153</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>DesktopSwitch settings</string>
   </property>
@@ -26,7 +34,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Desktop labels:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttons">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -34,6 +49,20 @@
      <property name="standardButtons">
       <set>QDialogButtonBox::Close</set>
      </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="labelTypeCB">
+     <item>
+      <property name="text">
+       <string>Numbers</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Names</string>
+      </property>
+     </item>
     </widget>
    </item>
   </layout>

--- a/plugin-desktopswitch/desktopswitchconfiguration.ui
+++ b/plugin-desktopswitch/desktopswitchconfiguration.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelRowsSB">
      <property name="text">
       <string>Number of rows:</string>
      </property>
@@ -35,7 +35,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelButtons">
      <property name="text">
       <string>Desktop labels:</string>
      </property>


### PR DESCRIPTION
(note: includes PR #155 since that's what I was working on initially)
This is a work in progress but basically what it does is:

* initially create the button in the `DesktopSwitch` constructor
* create and delete buttons in `onNumberOfDesktopChanged` if needed
* refresh by modifying existing buttons

The performance difference is obvious for everything that needs a refresh (adding/deleting desktops or changing the configuration), it took 2 to 3 seconds to refresh and now it's basically instantaneous. And there probably still are a lots of call to refresh that could be avoided.

I haven't really looked at the shortcuts yet, so it's very likely that as of right now this PR breaks them.