### PR TITLE
panel: widgets manageable from "add plugin dialog"

### DIFF
--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -34,6 +34,7 @@
 #include <QTimer>
 #include "ilxqtpanel.h"
 #include "lxqtpanelglobals.h"
+#include <LXQt/AddPluginDialog>
 
 class QMenu;
 class Plugin;
@@ -122,8 +123,8 @@ signals:
     void realigned();
     void deletedByUser(LxQtPanel *self);
 
-    void pluginAdded(QString id);
-    void pluginRemoved(QString id);
+    void pluginAdded(LxQt::PluginData const & plugin);
+    void pluginRemoved(LxQt::PluginData const & plugin);
 
 protected:
     bool event(QEvent *event);

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -69,7 +69,7 @@ public:
     QMenu* popupMenu() const;
     ILxQtPanelPlugin * iPlugin() const { return mPlugin; }
 
-    const LxQt::PluginInfo desktopFile() { return mDesktopFile; }
+    const LxQt::PluginInfo desktopFile() const { return mDesktopFile; }
 
     bool isSeparate() const;
     bool isExpandable() const;


### PR DESCRIPTION
references lxde/lxqt#536, lxde/lxqt#552 (and maybe others)

Added support for manaing of widgets in the old "add plugin dialog" -> just forward the context menu for each one to the dialog.

Note: must be merged right after lxde/liblxqt#38