### PR TITLE
Refactoring of panel's main

### DIFF
--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -34,12 +34,31 @@
 #include <QUuid>
 #include <QScreen>
 #include <QWindow>
+#include <QCommandLineParser>
 
-LxQtPanelApplication::LxQtPanelApplication(int& argc, char** argv, const QString &configFile)
+LxQtPanelApplication::LxQtPanelApplication(int& argc, char** argv)
     : LxQt::Application(argc, argv)
 {
+    QCoreApplication::setApplicationName(QStringLiteral("lxqt-panel"));
+    QCoreApplication::setApplicationVersion(LXQT_VERSION);
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QStringLiteral("LXQt panel"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption configFileOption(QStringList()
+            << QStringLiteral("c") << QStringLiteral("config") << QStringLiteral("configfile"),
+            QCoreApplication::translate("main", "Use alternate configuration file."),
+            QCoreApplication::translate("main", "Configuration file"));
+    parser.addOption(configFileOption);
+
+    parser.process(*this);
+
+    const QString configFile = parser.value(configFileOption);
+
     if (configFile.isEmpty())
-        mSettings = new LxQt::Settings("panel", this);
+        mSettings = new LxQt::Settings(QStringLiteral("panel"), this);
     else
         mSettings = new LxQt::Settings(configFile, QSettings::IniFormat, this);
 

--- a/panel/lxqtpanelapplication.h
+++ b/panel/lxqtpanelapplication.h
@@ -43,7 +43,7 @@ class LxQtPanelApplication : public LxQt::Application
 {
     Q_OBJECT
 public:
-    explicit LxQtPanelApplication(int& argc, char** argv, const QString &configFile);
+    explicit LxQtPanelApplication(int& argc, char** argv);
     ~LxQtPanelApplication();
 
     int count() { return mPanels.count(); }

--- a/panel/main.cpp
+++ b/panel/main.cpp
@@ -31,6 +31,7 @@
 #include <QDebug>
 #include <QLibraryInfo>
 #include <QDirIterator>
+#include <QCommandLineParser>
 #include <csignal>
 
 #include "lxqtpanelapplication.h"
@@ -48,65 +49,14 @@ void termSignalHandler(int)
         qApp->quit();
 }
 
-
-void printHelp()
-{
-    QTextStream out(stdout);
-    out << "Usage: lxqt-panel [options]" << endl;
-    out << endl;
-    out << "Start lxde-qt panel and its plugins" << endl;
-    out << endl;
-    out << "Options:" << endl;
-    out << "  -h, --help                    Show help about options" << endl;
-    out << "      --version                 Show version information" << endl;
-    out << "  -c, --configfile=CONFIGFILE   Use alternate configuration file" << endl;
-}
-
-
-void printVersion()
-{
-    QTextStream out(stdout);
-    out << "lxqt-panel " << LXQT_VERSION << endl;
-}
-
-
 int main(int argc, char *argv[])
 {
-    QString configFile;
-    for (int i=1; i < argc; ++i)
-    {
-        QString arg = QString::fromLocal8Bit(argv[i]);
-
-        if (arg == "--help" || arg == "-h")
-        {
-            printHelp();
-            return 0;
-        }
-
-        if (arg == "--version")
-        {
-            printVersion();
-            return 0;
-        }
-
-        if (arg == "-c" || arg.startsWith("--conf"))
-        {
-            if (i+1 < argc)
-            {
-                configFile = QString::fromLocal8Bit(argv[i+1]);
-            }
-        }
-    }
-
-    QScopedPointer<LxQtPanelApplication> app(new LxQtPanelApplication(argc, argv, configFile));
-
+    LxQtPanelApplication app(argc, argv);
 
     // Quit gracefully
     ::signal(SIGTERM, termSignalHandler);
     ::signal(SIGINT,  termSignalHandler);
     ::signal(SIGHUP,  termSignalHandler);
 
-    bool res = app->exec();
-
-    return res;
+    return app.exec();
 }


### PR DESCRIPTION
* Replace argument parsing with QCommandLineArgumentParser.
  * Handles command line options parsing.
  * Handles the `--help` and `--version`.
  * Version number stored in the application object.
  * ~~Init function for LxQtPanelApplication, the application is needed
    for the argument parsing, so we move its full initialization later,
    once we have parsed the arguments and retrieved the config file
    path (if any).~~

* Allocate the application on the stack
  For some reason, the panel application was allocated on the heap, that
  doesn't seem necessary and is less efficient than simply allocating it
  on the stack.