### PR TITLE
plugin-taskbar: show only minimized windows & raise on current desktop

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -58,6 +58,7 @@ LxQtTaskBar::LxQtTaskBar(ILxQtPanelPlugin *plugin, QWidget *parent) :
     mCloseOnMiddleClick(true),
     mShowOnlyCurrentDesktopTasks(false),
     mShowOnlyCurrentScreenTasks(false),
+    mShowOnlyMinimizedTasks(false),
     mAutoRotate(true),
     mShowGroupOnHover(true),
     mPlugin(plugin),
@@ -353,6 +354,7 @@ void LxQtTaskBar::settingsChanged()
     bool groupingEnabledOld = mGroupingEnabled;
     bool showOnlyCurrentDesktopTasksOld = mShowOnlyCurrentDesktopTasks;
     bool showOnlyCurrentScreenTasksOld = mShowOnlyCurrentScreenTasks;
+    bool showOnlyMinimizedTasksOld = mShowOnlyMinimizedTasks;
 
     mButtonWidth = mPlugin->settings()->value("buttonWidth", 400).toInt();
     mButtonHeight = mPlugin->settings()->value("buttonHeight", 100).toInt();
@@ -367,6 +369,7 @@ void LxQtTaskBar::settingsChanged()
 
     mShowOnlyCurrentDesktopTasks = mPlugin->settings()->value("showOnlyCurrentDesktopTasks", mShowOnlyCurrentDesktopTasks).toBool();
     mShowOnlyCurrentScreenTasks = mPlugin->settings()->value("showOnlyCurrentScreenTasks", mShowOnlyCurrentScreenTasks).toBool();
+    mShowOnlyMinimizedTasks = mPlugin->settings()->value("showOnlyMinimizedTasks", mShowOnlyMinimizedTasks).toBool();
     mAutoRotate = mPlugin->settings()->value("autoRotate", true).toBool();
     mCloseOnMiddleClick = mPlugin->settings()->value("closeOnMiddleClick", true).toBool();
     mGroupingEnabled = mPlugin->settings()->value("groupingEnabled",true).toBool();
@@ -384,7 +387,9 @@ void LxQtTaskBar::settingsChanged()
     }
 
     if (showOnlyCurrentDesktopTasksOld != mShowOnlyCurrentDesktopTasks
-            || showOnlyCurrentScreenTasksOld != mShowOnlyCurrentScreenTasks)
+            || showOnlyCurrentScreenTasksOld != mShowOnlyCurrentScreenTasks
+            || showOnlyMinimizedTasksOld != mShowOnlyMinimizedTasks
+            )
         Q_FOREACH (LxQtTaskGroup *group, mGroupsHash)
             group->showOnlySettingChanged();
 

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -56,6 +56,7 @@ LxQtTaskBar::LxQtTaskBar(ILxQtPanelPlugin *plugin, QWidget *parent) :
     QFrame(parent),
     mButtonStyle(Qt::ToolButtonTextBesideIcon),
     mCloseOnMiddleClick(true),
+    mRaiseOnCurrentDesktop(true),
     mShowOnlyCurrentDesktopTasks(false),
     mShowOnlyCurrentScreenTasks(false),
     mShowOnlyMinimizedTasks(false),
@@ -372,6 +373,7 @@ void LxQtTaskBar::settingsChanged()
     mShowOnlyMinimizedTasks = mPlugin->settings()->value("showOnlyMinimizedTasks", mShowOnlyMinimizedTasks).toBool();
     mAutoRotate = mPlugin->settings()->value("autoRotate", true).toBool();
     mCloseOnMiddleClick = mPlugin->settings()->value("closeOnMiddleClick", true).toBool();
+    mRaiseOnCurrentDesktop = mPlugin->settings()->value("raiseOnCurrentDesktop", false).toBool();
     mGroupingEnabled = mPlugin->settings()->value("groupingEnabled",true).toBool();
     mShowGroupOnHover = mPlugin->settings()->value("showGroupOnHover",true).toBool();
 

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -70,6 +70,7 @@ public:
     bool closeOnMiddleClick() { return mCloseOnMiddleClick; }
     bool isShowOnlyCurrentDesktopTasks() { return mShowOnlyCurrentDesktopTasks; }
     bool isShowOnlyCurrentScreenTasks() { return mShowOnlyCurrentScreenTasks; }
+    bool isShowOnlyMinimizedTasks() { return mShowOnlyMinimizedTasks; }
     bool isAutoRotate() { return mAutoRotate; }
     bool isGroupingEnabled() { return mGroupingEnabled; }
     bool isShowGroupOnHover() { return mShowGroupOnHover; }
@@ -104,6 +105,7 @@ private:
     bool mCloseOnMiddleClick;
     bool mShowOnlyCurrentDesktopTasks;
     bool mShowOnlyCurrentScreenTasks;
+    bool mShowOnlyMinimizedTasks;
     bool mAutoRotate;
     bool mGroupingEnabled;
     bool mShowGroupOnHover;

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -68,6 +68,7 @@ public:
     Qt::ToolButtonStyle buttonStyle() { return mButtonStyle; }
     int buttonWidth() { return mButtonWidth; }
     bool closeOnMiddleClick() { return mCloseOnMiddleClick; }
+    bool raiseOnCurrentDesktop() { return mRaiseOnCurrentDesktop; }
     bool isShowOnlyCurrentDesktopTasks() { return mShowOnlyCurrentDesktopTasks; }
     bool isShowOnlyCurrentScreenTasks() { return mShowOnlyCurrentScreenTasks; }
     bool isShowOnlyMinimizedTasks() { return mShowOnlyMinimizedTasks; }
@@ -103,6 +104,7 @@ private:
     int mButtonWidth;
     int mButtonHeight;
     bool mCloseOnMiddleClick;
+    bool mRaiseOnCurrentDesktop;
     bool mShowOnlyCurrentDesktopTasks;
     bool mShowOnlyCurrentScreenTasks;
     bool mShowOnlyMinimizedTasks;

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -53,6 +53,7 @@ LxQtTaskbarConfiguration::LxQtTaskbarConfiguration(QSettings &settings, QWidget 
         change of state */
     connect(ui->limitByDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->limitByScreenCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->limitByMinimizedCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->buttonStyleCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
     connect(ui->buttonWidthSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     connect(ui->buttonHeightSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
@@ -71,6 +72,7 @@ void LxQtTaskbarConfiguration::loadSettings()
 {
     ui->limitByDesktopCB->setChecked(mSettings.value("showOnlyCurrentDesktopTasks", false).toBool());
     ui->limitByScreenCB->setChecked(mSettings.value("showOnlyCurrentScreenTasks", false).toBool());
+    ui->limitByMinimizedCB->setChecked(mSettings.value("showOnlyMinimizedTasks", false).toBool());
 
     ui->autoRotateCB->setChecked(mSettings.value("autoRotate", true).toBool());
     ui->middleClickCB->setChecked(mSettings.value("closeOnMiddleClick", true).toBool());
@@ -85,6 +87,7 @@ void LxQtTaskbarConfiguration::saveSettings()
 {
     mSettings.setValue("showOnlyCurrentDesktopTasks", ui->limitByDesktopCB->isChecked());
     mSettings.setValue("showOnlyCurrentScreenTasks", ui->limitByScreenCB->isChecked());
+    mSettings.setValue("showOnlyMinimizedTasks", ui->limitByMinimizedCB->isChecked());
     mSettings.setValue("buttonStyle", ui->buttonStyleCB->itemData(ui->buttonStyleCB->currentIndex()));
     mSettings.setValue("buttonWidth", ui->buttonWidthSB->value());
     mSettings.setValue("buttonHeight", ui->buttonHeightSB->value());

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -54,6 +54,7 @@ LxQtTaskbarConfiguration::LxQtTaskbarConfiguration(QSettings &settings, QWidget 
     connect(ui->limitByDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->limitByScreenCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->limitByMinimizedCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
+    connect(ui->raiseOnCurrentDesktopCB, SIGNAL(clicked()), this, SLOT(saveSettings()));
     connect(ui->buttonStyleCB, SIGNAL(activated(int)), this, SLOT(saveSettings()));
     connect(ui->buttonWidthSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
     connect(ui->buttonHeightSB, SIGNAL(valueChanged(int)), this, SLOT(saveSettings()));
@@ -76,6 +77,7 @@ void LxQtTaskbarConfiguration::loadSettings()
 
     ui->autoRotateCB->setChecked(mSettings.value("autoRotate", true).toBool());
     ui->middleClickCB->setChecked(mSettings.value("closeOnMiddleClick", true).toBool());
+    ui->raiseOnCurrentDesktopCB->setChecked(mSettings.value("raiseOnCurrentDesktop", false).toBool());
     ui->buttonStyleCB->setCurrentIndex(ui->buttonStyleCB->findData(mSettings.value("buttonStyle", "IconText")));
     ui->buttonWidthSB->setValue(mSettings.value("buttonWidth", 400).toInt());
     ui->buttonHeightSB->setValue(mSettings.value("buttonHeight", 100).toInt());
@@ -93,6 +95,7 @@ void LxQtTaskbarConfiguration::saveSettings()
     mSettings.setValue("buttonHeight", ui->buttonHeightSB->value());
     mSettings.setValue("autoRotate", ui->autoRotateCB->isChecked());
     mSettings.setValue("closeOnMiddleClick", ui->middleClickCB->isChecked());
+    mSettings.setValue("raiseOnCurrentDesktop", ui->raiseOnCurrentDesktopCB->isChecked());
     mSettings.setValue("groupingEnabled",ui->groupingGB->isChecked());
     mSettings.setValue("showGroupOnHover",ui->showGroupOnHoverCB->isChecked());
 }

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -42,6 +42,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="raiseOnCurrentDesktopCB">
+        <property name="text">
+         <string>Raise minimized windows on current desktop</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="middleClickCB">
         <property name="text">
          <string>Close on middle-click</string>

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>356</width>
-    <height>370</height>
+    <width>401</width>
+    <height>484</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,6 +31,13 @@
        <widget class="QCheckBox" name="limitByScreenCB">
         <property name="text">
          <string>Show only windows from &amp;panel's screen</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="limitByMinimizedCB">
+        <property name="text">
+         <string>Show only minimized windows</string>
         </property>
        </widget>
       </item>

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -587,6 +587,10 @@ bool LxQtTaskButton::isOnCurrentScreen() const
     return QApplication::desktop()->screenGeometry(parentTaskBar()).intersects(KWindowInfo(mWindow, NET::WMFrameExtents).frameGeometry());
 }
 
+bool LxQtTaskButton::isMinimized() const
+{
+    return KWindowInfo(mWindow,NET::WMState | NET::XAWMState).isMinimized();
+}
 
 Qt::Corner LxQtTaskButton::origin() const
 {

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -291,10 +291,17 @@ void LxQtTaskButton::activateWithDraggable()
  ************************************************/
 void LxQtTaskButton::raiseApplication()
 {
-    KWindowInfo info(mWindow, NET::WMDesktop);
-    int winDesktop = info.desktop();
-    if (KWindowSystem::currentDesktop() != winDesktop)
-        KWindowSystem::setCurrentDesktop(winDesktop);
+    KWindowInfo info(mWindow, NET::WMDesktop | NET::WMState | NET::XAWMState);
+    if (parentTaskBar()->raiseOnCurrentDesktop() && info.isMinimized())
+    {
+        KWindowSystem::setOnDesktop(mWindow, KWindowSystem::currentDesktop());
+    }
+    else
+    {
+        int winDesktop = info.desktop();
+        if (KWindowSystem::currentDesktop() != winDesktop)
+            KWindowSystem::setCurrentDesktop(winDesktop);
+    }
     KWindowSystem::activateWindow(mWindow);
 
     setUrgencyHint(false);

--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -72,6 +72,7 @@ public:
 
     bool isOnDesktop(int desktop) const;
     bool isOnCurrentScreen() const;
+    bool isMinimized() const;
     void updateText();
     void updateIcon();
 

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -372,6 +372,7 @@ void LxQtTaskGroup::refreshVisibility()
     {
         bool visible = parentTaskBar()->isShowOnlyCurrentDesktopTasks() ? btn->isOnDesktop(KWindowSystem::currentDesktop()) : true;
         visible &= parentTaskBar()->isShowOnlyCurrentScreenTasks() ? btn->isOnCurrentScreen() : true;
+        visible &= parentTaskBar()->isShowOnlyMinimizedTasks() ? btn->isMinimized() : true;
         btn->setVisible(visible);
         will |= visible;
     }
@@ -579,6 +580,7 @@ void LxQtTaskGroup::mouseMoveEvent(QMouseEvent* event)
 bool LxQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2)
 {
     bool consumed{false};
+    bool needsRefreshVisibility{false};
     QVector<LxQtTaskButton *> buttons;
     if (mButtonHash.contains(window))
         buttons.append(mButtonHash.value(window));
@@ -610,7 +612,7 @@ bool LxQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Prope
             if (parentTaskBar()->isShowOnlyCurrentDesktopTasks()
                     || parentTaskBar()->isShowOnlyCurrentScreenTasks())
             {
-                refreshVisibility();
+                needsRefreshVisibility = true;
             }
         }
 
@@ -634,7 +636,16 @@ bool LxQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Prope
                 continue;
             }
             button->setUrgencyHint(info.hasState(NET::DemandsAttention));
+
+            if (parentTaskBar()->isShowOnlyMinimizedTasks())
+            {
+                needsRefreshVisibility = true;
+            }
         }
     }
+
+    if (needsRefreshVisibility)
+        refreshVisibility();
+
     return consumed;
 }


### PR DESCRIPTION
This PR adds two options to the taskbar:

* Show only minimized windows in the taskbar

* Raise minimized windows on the current desktop, with this option, when clicking on a minimized window in the task bar, instead of switching to the window's desktop and raising it, it moves the window to the current desktop and raises it.

With these two options, we can use the taskbar as a kind of *desktop independent storage* for minimized application.