### PR TITLE
plugin-taskbar: don't stretch along the panel in icon only

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -70,7 +70,6 @@ LxQtTaskBar::LxQtTaskBar(ILxQtPanelPlugin *plugin, QWidget *parent) :
     mLayout = new LxQt::GridLayout(this);
     setLayout(mLayout);
     mLayout->setMargin(0);
-    mLayout->setStretch(LxQt::GridLayout::StretchHorizontal | LxQt::GridLayout::StretchVertical);
     realign();
 
     mPlaceHolder->setMinimumSize(1, 1);
@@ -361,11 +360,20 @@ void LxQtTaskBar::settingsChanged()
     QString s = mPlugin->settings()->value("buttonStyle").toString().toUpper();
 
     if (s == "ICON")
+    {
         setButtonStyle(Qt::ToolButtonIconOnly);
-    else if (s == "TEXT")
-        setButtonStyle(Qt::ToolButtonTextOnly);
+        mLayout->setStretch(mPlugin->panel()->isHorizontal() ?
+                            LxQt::GridLayout::StretchVertical :
+                            LxQt::GridLayout::StretchHorizontal);
+    }
     else
-        setButtonStyle(Qt::ToolButtonTextBesideIcon);
+    {
+        if (s == "TEXT")
+            setButtonStyle(Qt::ToolButtonTextOnly);
+        else
+            setButtonStyle(Qt::ToolButtonTextBesideIcon);
+        mLayout->setStretch(LxQt::GridLayout::StretchHorizontal | LxQt::GridLayout::StretchVertical);
+    }
 
     mShowOnlyCurrentDesktopTasks = mPlugin->settings()->value("showOnlyCurrentDesktopTasks", mShowOnlyCurrentDesktopTasks).toBool();
     mShowOnlyCurrentScreenTasks = mPlugin->settings()->value("showOnlyCurrentScreenTasks", mShowOnlyCurrentScreenTasks).toBool();
@@ -443,6 +451,11 @@ void LxQtTaskBar::realign()
             }
         }
     }
+
+    if (mButtonStyle == Qt::ToolButtonIconOnly)
+        mLayout->setStretch(panel->isHorizontal() ?
+                            LxQt::GridLayout::StretchVertical :
+                            LxQt::GridLayout::StretchHorizontal);
 
     mLayout->setCellMinimumSize(minSize);
     mLayout->setCellMaximumSize(maxSize);


### PR DESCRIPTION
Don't stretch the taskbar's buttons along the panel in `IconOnly` mode. It avoids having a big button with only a small icon in the middle.