### PR TITLE
plugin-taskbar: show only particular(configurable) desktop windows

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -57,7 +57,8 @@ LxQtTaskBar::LxQtTaskBar(ILxQtPanelPlugin *plugin, QWidget *parent) :
     mButtonStyle(Qt::ToolButtonTextBesideIcon),
     mCloseOnMiddleClick(true),
     mRaiseOnCurrentDesktop(true),
-    mShowOnlyCurrentDesktopTasks(false),
+    mShowOnlyOneDesktopTasks(false),
+    mShowDesktopNum(0),
     mShowOnlyCurrentScreenTasks(false),
     mShowOnlyMinimizedTasks(false),
     mAutoRotate(true),
@@ -352,7 +353,8 @@ void LxQtTaskBar::setButtonStyle(Qt::ToolButtonStyle buttonStyle)
 void LxQtTaskBar::settingsChanged()
 {
     bool groupingEnabledOld = mGroupingEnabled;
-    bool showOnlyCurrentDesktopTasksOld = mShowOnlyCurrentDesktopTasks;
+    bool showOnlyOneDesktopTasksOld = mShowOnlyOneDesktopTasks;
+    const int showDesktopNumOld = mShowDesktopNum;
     bool showOnlyCurrentScreenTasksOld = mShowOnlyCurrentScreenTasks;
     bool showOnlyMinimizedTasksOld = mShowOnlyMinimizedTasks;
 
@@ -367,7 +369,8 @@ void LxQtTaskBar::settingsChanged()
     else
         setButtonStyle(Qt::ToolButtonTextBesideIcon);
 
-    mShowOnlyCurrentDesktopTasks = mPlugin->settings()->value("showOnlyCurrentDesktopTasks", mShowOnlyCurrentDesktopTasks).toBool();
+    mShowOnlyOneDesktopTasks = mPlugin->settings()->value("showOnlyOneDesktopTasks", mShowOnlyOneDesktopTasks).toBool();
+    mShowDesktopNum = mPlugin->settings()->value("showDesktopNum", mShowDesktopNum).toInt();
     mShowOnlyCurrentScreenTasks = mPlugin->settings()->value("showOnlyCurrentScreenTasks", mShowOnlyCurrentScreenTasks).toBool();
     mShowOnlyMinimizedTasks = mPlugin->settings()->value("showOnlyMinimizedTasks", mShowOnlyMinimizedTasks).toBool();
     mAutoRotate = mPlugin->settings()->value("autoRotate", true).toBool();
@@ -387,7 +390,8 @@ void LxQtTaskBar::settingsChanged()
         mGroupsHash.clear();
     }
 
-    if (showOnlyCurrentDesktopTasksOld != mShowOnlyCurrentDesktopTasks
+    if (showOnlyOneDesktopTasksOld != mShowOnlyOneDesktopTasks
+            || (mShowOnlyOneDesktopTasks && showDesktopNumOld != mShowDesktopNum)
             || showOnlyCurrentScreenTasksOld != mShowOnlyCurrentScreenTasks
             || showOnlyMinimizedTasksOld != mShowOnlyMinimizedTasks
             )

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -65,16 +65,17 @@ public:
 
     void realign();
 
-    Qt::ToolButtonStyle buttonStyle() { return mButtonStyle; }
-    int buttonWidth() { return mButtonWidth; }
-    bool closeOnMiddleClick() { return mCloseOnMiddleClick; }
-    bool raiseOnCurrentDesktop() { return mRaiseOnCurrentDesktop; }
-    bool isShowOnlyCurrentDesktopTasks() { return mShowOnlyCurrentDesktopTasks; }
-    bool isShowOnlyCurrentScreenTasks() { return mShowOnlyCurrentScreenTasks; }
-    bool isShowOnlyMinimizedTasks() { return mShowOnlyMinimizedTasks; }
-    bool isAutoRotate() { return mAutoRotate; }
-    bool isGroupingEnabled() { return mGroupingEnabled; }
-    bool isShowGroupOnHover() { return mShowGroupOnHover; }
+    Qt::ToolButtonStyle buttonStyle() const { return mButtonStyle; }
+    int buttonWidth() const { return mButtonWidth; }
+    bool closeOnMiddleClick() const { return mCloseOnMiddleClick; }
+    bool raiseOnCurrentDesktop() const { return mRaiseOnCurrentDesktop; }
+    bool isShowOnlyOneDesktopTasks() const { return mShowOnlyOneDesktopTasks; }
+    int showDesktopNum() const { return mShowDesktopNum; }
+    bool isShowOnlyCurrentScreenTasks() const { return mShowOnlyCurrentScreenTasks; }
+    bool isShowOnlyMinimizedTasks() const { return mShowOnlyMinimizedTasks; }
+    bool isAutoRotate() const { return mAutoRotate; }
+    bool isGroupingEnabled() const { return mGroupingEnabled; }
+    bool isShowGroupOnHover() const { return mShowGroupOnHover; }
 
 public slots:
     void settingsChanged();
@@ -105,7 +106,8 @@ private:
     int mButtonHeight;
     bool mCloseOnMiddleClick;
     bool mRaiseOnCurrentDesktop;
-    bool mShowOnlyCurrentDesktopTasks;
+    bool mShowOnlyOneDesktopTasks;
+    int mShowDesktopNum;
     bool mShowOnlyCurrentScreenTasks;
     bool mShowOnlyMinimizedTasks;
     bool mAutoRotate;

--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -21,11 +21,24 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QCheckBox" name="limitByDesktopCB">
-        <property name="text">
-         <string>Show only windows from c&amp;urrent desktop</string>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="margin">
+         <number>0</number>
         </property>
-       </widget>
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="limitByDesktopCB">
+          <property name="text">
+           <string>Show only windows from desktop</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="showDesktopNumCB"/>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QCheckBox" name="limitByScreenCB">

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -368,11 +368,13 @@ void LxQtTaskGroup::setAutoRotation(bool value, ILxQtPanel::Position position)
 void LxQtTaskGroup::refreshVisibility()
 {
     bool will = false;
+    LxQtTaskBar const * taskbar = parentTaskBar();
+    const int showDesktop = taskbar->showDesktopNum();
     foreach(LxQtTaskButton * btn, mButtonHash.values())
     {
-        bool visible = parentTaskBar()->isShowOnlyCurrentDesktopTasks() ? btn->isOnDesktop(KWindowSystem::currentDesktop()) : true;
-        visible &= parentTaskBar()->isShowOnlyCurrentScreenTasks() ? btn->isOnCurrentScreen() : true;
-        visible &= parentTaskBar()->isShowOnlyMinimizedTasks() ? btn->isMinimized() : true;
+        bool visible = taskbar->isShowOnlyOneDesktopTasks() ? btn->isOnDesktop(0 == showDesktop ? KWindowSystem::currentDesktop() : showDesktop) : true;
+        visible &= taskbar->isShowOnlyCurrentScreenTasks() ? btn->isOnCurrentScreen() : true;
+        visible &= taskbar->isShowOnlyMinimizedTasks() ? btn->isMinimized() : true;
         btn->setVisible(visible);
         will |= visible;
     }
@@ -609,7 +611,7 @@ bool LxQtTaskGroup::onWindowChanged(WId window, NET::Properties prop, NET::Prope
         // window changed virtual desktop
         if (prop.testFlag(NET::WMDesktop) || prop.testFlag(NET::WMGeometry))
         {
-            if (parentTaskBar()->isShowOnlyCurrentDesktopTasks()
+            if (parentTaskBar()->isShowOnlyOneDesktopTasks()
                     || parentTaskBar()->isShowOnlyCurrentScreenTasks())
             {
                 needsRefreshVisibility = true;


### PR DESCRIPTION
Adds posibility to have windows arranged by desktop(s) -> multiple taskbar widgets each showing only particular desktop windows. E.g. 3 desktops:
![screenshot](https://cloud.githubusercontent.com/assets/10990929/7561623/c6d8f99c-f7cd-11e4-9866-92b67d89cd62.png)

This is a workaround/enhancement for lxde/lxqt#102 and/or lxde/lxqt#641

@Vladimir-csp can you, please, check if this is usable for your needs?