### PR TITLE
Improve multi-monitor support

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -169,7 +169,7 @@ LxQtPanel::LxQtPanel(const QString &configGroup, QWidget *parent) :
     mHideTimer.setInterval(PANEL_HIDE_DELAY);
     connect(&mHideTimer, SIGNAL(timeout()), this, SLOT(hidePanelWork()));
 
-    connect(QApplication::desktop(), SIGNAL(resized(int)), this, SLOT(realign()));
+    connect(QApplication::desktop(), SIGNAL(workAreaResized(int)), this, SLOT(realign()));
     connect(QApplication::desktop(), SIGNAL(screenCountChanged(int)), this, SLOT(ensureVisible()));
     connect(LxQt::Settings::globalSettings(), SIGNAL(settingsChanged()), this, SLOT(update()));
     connect(lxqtApp, SIGNAL(themeChanged()), this, SLOT(realign()));


### PR DESCRIPTION
lxqt-panel is not always resized and repositioned correctly after applying a monitor configuration (e.g. changing screen's resolution). Apparently, that's a bug in Qt. The panel listened to `QDesktopWidget::resized` signal, which was not always emitted. Making it listen to the `workAreaChanged` signal seems to solve the problem.

This is an attempt to fix issues like lxde/lxqt#650 and lxde/lxqt#520. Reading `QDesktopWidget`'s [source](https://github.com/qtproject/qtbase/blob/5.4.2/src/widgets/kernel/qdesktopwidget.cpp) helped a little, but this needs testing.

@pmattern, @Vladimir-csp and @hduff: please, test this if you can.

The bug I can reproduce is that after changing my screen's resolution repeatedly, lxqt-panel would eventually not reset its size and position, as it should.