### PR TITLE
plugin-clock: use Qt::PreciseTimer for better accuracy

### DIFF
--- a/plugin-clock/lxqtclock.h
+++ b/plugin-clock/lxqtclock.h
@@ -92,8 +92,8 @@ private:
     QScopedPointer<QProxyStyle> mTextStyle;
 
     QDateTime currentDateTime();
-    void showTime(const QDateTime &);
-    void restartTimer(const QDateTime&);
+    void showTime();
+    void restartTimer();
 };
 
 


### PR DESCRIPTION
With use of Qt::CoarseTimer (5% accuracy) the shown time can be up to one minute behind.
(e.g.: change configuration to not show seconds right after whole minute -> update is scheduled
after cca 60 secs (with 5% accuracy), that means it can occure in 58.5 ~ 61.5 secs... and we have a problem)