### PR TITLE
plugin-desktopswitch: Check if the button exists dereferencing it.

### DIFF
--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -121,7 +121,8 @@ void DesktopSwitch::onWindowChanged(WId id, NET::Properties properties, NET::Pro
         else
         {
             DesktopSwitchButton *button = static_cast<DesktopSwitchButton *>(m_buttons->button(desktop - 1));
-            button->setUrgencyHint(id, info.hasState(NET::DemandsAttention));
+            if(button)
+                button->setUrgencyHint(id, info.hasState(NET::DemandsAttention));
         }
     }
 }


### PR DESCRIPTION
The button method will return 0 if there was no buttons at the given index. And since the value of the desktop variable comes from `_NET_WM_DESKTOP` it can absolutely happen depending on what's set as `_NET_WM_DESKTOP` by the window manager (and actually happens on i3 every time a window is switched to fullscreen).

Anyway this kind of sanity check is always good for reliability.