### PR TITLE
panel: only for supported objects the iconSize qproperty styling is applied

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -603,8 +603,8 @@ void LxQtPanel::showAddPluginDialog()
 void LxQtPanel::updateStyleSheet()
 {
     QStringList sheet;
-    sheet << QString("Plugin > * { qproperty-iconSize: %1px %1px; }").arg(mIconSize);
-    sheet << QString("Plugin > * > * { qproperty-iconSize: %1px %1px; }").arg(mIconSize);
+    sheet << QString("Plugin > QAbstractButton, LxQtTray { qproperty-iconSize: %1px %1px; }").arg(mIconSize);
+    sheet << QString("Plugin > * > QAbstractButton, TrayIcon { qproperty-iconSize: %1px %1px; }").arg(mIconSize);
 
     if (mFontColor.isValid())
         sheet << QString("Plugin * { color: " + mFontColor.name() + "; }");

--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -225,6 +225,7 @@ TrayIcon* LxQtTray::findIcon(Window id)
 ************************************************/
 void LxQtTray::setIconSize(QSize iconSize)
 {
+    mIconSize = iconSize;
     unsigned long size = qMin(mIconSize.width(), mIconSize.height());
     XChangeProperty(mDisplay,
                     mTrayId,
@@ -234,10 +235,6 @@ void LxQtTray::setIconSize(QSize iconSize)
                     PropModeReplace,
                     (unsigned char*)&size,
                     1);
-
-    mIconSize = iconSize;
-    foreach(TrayIcon* icon, mIcons)
-        icon->setIconSize(mIconSize);
 }
 
 
@@ -384,7 +381,6 @@ void LxQtTray::addIcon(Window winId)
         return;
     }
 
-    icon->setIconSize(mIconSize);
     mIcons.append(icon);
     mLayout->addWidget(icon);
 }


### PR DESCRIPTION
This avoids all of the `<Class>(0xb1e830, name = <name>)  does not have a property named  "iconSize"` warnings