### PR TITLE
plugin-volume: handle maximum volume proportionally

### DIFF
--- a/plugin-volume/audiodevice.cpp
+++ b/plugin-volume/audiodevice.cpp
@@ -26,7 +26,6 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include "audiodevice.h"
-
 #include "audioengine.h"
 
 AudioDevice::AudioDevice(AudioDeviceType t, AudioEngine *engine, QObject *parent) :
@@ -74,7 +73,7 @@ void AudioDevice::setIndex(uint index)
 void AudioDevice::setVolumeNoCommit(int volume)
 {
     if (m_engine)
-        volume = qBound(0, volume, m_engine->volumeMax(this));
+        volume = m_engine->volumeBounded(volume, this);
 
     if (m_volume == volume)
         return;

--- a/plugin-volume/audiodevice.h
+++ b/plugin-volume/audiodevice.h
@@ -59,7 +59,7 @@ public:
     void setName(const QString &name);
     void setDescription(const QString &description);
     void setIndex(uint index);
-    
+
     AudioEngine* engine() { return m_engine; }
 
 public slots:

--- a/plugin-volume/audioengine.cpp
+++ b/plugin-volume/audioengine.cpp
@@ -43,6 +43,15 @@ AudioEngine::~AudioEngine()
     m_sinks.clear();
 }
 
+int AudioEngine::volumeBounded(int volume, AudioDevice* device) const
+{
+    int maximum = volumeMax(device);
+    double v = ((double) volume / 100.0) * maximum;
+    double bounded = qBound<double>(0, v, maximum);
+    return qRound((bounded / maximum) * 100);
+}
+
+
 void AudioEngine::mute(AudioDevice *device)
 {
     setMute(device, true);

--- a/plugin-volume/audioengine.h
+++ b/plugin-volume/audioengine.h
@@ -44,6 +44,7 @@ public:
 
     const QList<AudioDevice *> &sinks() const { return m_sinks; }
     virtual int volumeMax(AudioDevice *device) const = 0;
+    virtual int volumeBounded(int volume, AudioDevice *device) const;
     virtual const QString backendName() const = 0;
 
 public slots:


### PR DESCRIPTION
PulseAudio does not have a simple 0 to 100 volume scale. So dealing with
maximum volume must handle the volumes proportionally.

Fixes lxde/lxqt#252.