### PR TITLE
Make panel appear above all windows when auto-hide is enabled

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -338,21 +338,8 @@ void LxQtPanel::loadPlugins()
 /************************************************
 
  ************************************************/
-void LxQtPanel::realign()
+void LxQtPanel::setPanelGeometry()
 {
-    if (!isVisible())
-        return;
-#if 0
-    qDebug() << "** Realign *********************";
-    qDebug() << "PanelSize:   " << mPanelSize;
-    qDebug() << "IconSize:      " << mIconSize;
-    qDebug() << "LineCount:     " << mLineCount;
-    qDebug() << "Length:        " << mLength << (mLengthInPercents ? "%" : "px");
-    qDebug() << "Alignment:     " << (mAlignment == 0 ? "center" : (mAlignment < 0 ? "left" : "right"));
-    qDebug() << "Position:      " << positionToStr(mPosition) << "on" << mScreenNum;
-    qDebug() << "Plugins count: " << mPlugins.count();
-#endif
-
     const QRect currentScreen = QApplication::desktop()->screenGeometry(mScreenNum);
     QRect rect;
 
@@ -438,6 +425,24 @@ void LxQtPanel::realign()
         setGeometry(rect);
         setFixedSize(rect.size());
     }
+}
+
+void LxQtPanel::realign()
+{
+    if (!isVisible())
+        return;
+#if 0
+    qDebug() << "** Realign *********************";
+    qDebug() << "PanelSize:   " << mPanelSize;
+    qDebug() << "IconSize:      " << mIconSize;
+    qDebug() << "LineCount:     " << mLineCount;
+    qDebug() << "Length:        " << mLength << (mLengthInPercents ? "%" : "px");
+    qDebug() << "Alignment:     " << (mAlignment == 0 ? "center" : (mAlignment < 0 ? "left" : "right"));
+    qDebug() << "Position:      " << positionToStr(mPosition) << "on" << mScreenNum;
+    qDebug() << "Plugins count: " << mPlugins.count();
+#endif
+
+    setPanelGeometry();
 
     // Reserve our space on the screen ..........
     // It's possible that our geometry is not changed, but screen resolution is changed,
@@ -1074,7 +1079,7 @@ void LxQtPanel::showPanel()
         if (mHidden)
         {
             mHidden = false;
-            realign();
+            setPanelGeometry();
         }
     }
 }
@@ -1090,7 +1095,7 @@ void LxQtPanel::hidePanelWork()
     if (mHidable && !mHidden && !geometry().contains(QCursor::pos()))
     {
         mHidden = true;
-        realign();
+        setPanelGeometry();
     } else
     {
         mHideTimer.start();
@@ -1102,8 +1107,7 @@ void LxQtPanel::setHidable(bool hidable, bool save)
     if (mHidable == hidable)
         return;
 
-    mHidable = hidable;
-    mHidden = mHidable;
+    mHidable = mHidden = hidable;
 
     if (save)
         saveSettings(true);

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -160,6 +160,7 @@ private:
     void loadPlugins();
 
     void setPanelGeometry();
+    int getReserveDimension();
 
     int mPanelSize;
     int mIconSize;

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -159,6 +159,8 @@ private:
 
     void loadPlugins();
 
+    void setPanelGeometry();
+
     int mPanelSize;
     int mIconSize;
     int mLineCount;


### PR DESCRIPTION
The panel pushes (maximised) windows aside when moving from hidden to shown. A properly behaving panel with auto-hide enabled should appear above all windows, and not beside them; in other words: it should slide above them and not push them aside.

Buggy:
![buggy](https://cloud.githubusercontent.com/assets/1378718/8531941/6de9d6ce-2448-11e5-9881-57b3e3492b8d.gif)

Fixed:
![fixed](https://cloud.githubusercontent.com/assets/1378718/8531966/8b025c04-2448-11e5-9eef-0f5c569bfc04.gif)