### PR TITLE
Re-added plugin-kbindicator/translation directory.

### DIFF
--- a/plugin-kbindicator/translations/kbindicator.ts
+++ b/plugin-kbindicator/translations/kbindicator.ts
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>Content</name>
+    <message>
+        <location filename="../src/content.cpp" line="60"/>
+        <source>Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/content.cpp" line="60"/>
+        <source>Variant</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>KbdStateConfig</name>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="20"/>
+        <source>Leds</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="26"/>
+        <source>Show Caps Lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="33"/>
+        <source>Show Num Lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="40"/>
+        <source>Show Scroll Lock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="74"/>
+        <source>Show keyboard layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="99"/>
+        <source>Show flags instead labels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="106"/>
+        <source>Layout mode:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="116"/>
+        <source>Global</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="129"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="142"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="152"/>
+        <source>Configure layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/plugin-kbindicator/translations/kbindicator_de.desktop
+++ b/plugin-kbindicator/translations/kbindicator_de.desktop
@@ -1,0 +1,2 @@
+Name[de]=Tastatur-LED-Anzeige
+Comment[de]=Plugin zum Anzeigen der Tastatur-LEDs und Umschalten des Layouts.

--- a/plugin-kbindicator/translations/kbindicator_de.ts
+++ b/plugin-kbindicator/translations/kbindicator_de.ts
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name>Content</name>
+    <message>
+        <location filename="../src/content.cpp" line="60"/>
+        <source>Layout</source>
+        <translation>Layout</translation>
+    </message>
+    <message>
+        <location filename="../src/content.cpp" line="60"/>
+        <source>Variant</source>
+        <translation>Variante</translation>
+    </message>
+</context>
+<context>
+    <name>KbdStateConfig</name>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="14"/>
+        <source>Dialog</source>
+        <translation type="unfinished">blahblahblah</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="20"/>
+        <source>Leds</source>
+        <translation>LEDs</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="26"/>
+        <source>Show Caps Lock</source>
+        <translation>Feststelltaste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="33"/>
+        <source>Show Num Lock</source>
+        <translation>NumLock-Taste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="40"/>
+        <source>Show Scroll Lock</source>
+        <translation>Rollen-Taste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="74"/>
+        <source>Show keyboard layout</source>
+        <translation>Tastatur-Layout anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="99"/>
+        <source>Show flags instead labels</source>
+        <translation>Flaggen statt Kennung anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="106"/>
+        <source>Layout mode:</source>
+        <translation>Layout-Modus:</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="116"/>
+        <source>Global</source>
+        <translation>Global</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="129"/>
+        <source>Window</source>
+        <translation>Fenster</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="142"/>
+        <source>Application</source>
+        <translation>Anwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/kbdstateconfig.ui" line="152"/>
+        <source>Configure layouts</source>
+        <translation>Layout konfigurieren...</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
with updated template and german translation. Don't know why this directory has been deleted.