### PR TITLE
panel: QMenu positioning workaround for multihead/multipanel setup

### DIFF
--- a/panel/ilxqtpanel.h
+++ b/panel/ilxqtpanel.h
@@ -72,6 +72,7 @@ public:
      Helper functions for calculating global screen position of some popup window with windowSize size.
      If you need to show some popup window, you can use it, to get global screen position for the new window.
      **/
+    virtual QRect calculatePopupWindowPos(const QPoint &absolutePos, const QSize &windowSize) const = 0;
     virtual QRect calculatePopupWindowPos(const ILxQtPanelPlugin *plugin, const QSize &windowSize) const = 0;
 };
 

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -80,6 +80,7 @@ public:
     ILxQtPanel::Position position() const { return mPosition; }
     QRect globalGometry() const;
     Plugin *findPlugin(const ILxQtPanelPlugin *iPlugin) const;
+    QRect calculatePopupWindowPos(QPoint const & absolutePos, QSize const & windowSize) const;
     QRect calculatePopupWindowPos(const ILxQtPanelPlugin *plugin, const QSize &windowSize) const;
 
     // For QSS properties ..................

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -49,7 +49,6 @@
 
 class LxQtTaskButton;
 class ElidedButtonStyle;
-class ILxQtPanelPlugin;
 
 namespace LxQt {
 class GridLayout;
@@ -76,6 +75,7 @@ public:
     bool isAutoRotate() const { return mAutoRotate; }
     bool isGroupingEnabled() const { return mGroupingEnabled; }
     bool isShowGroupOnHover() const { return mShowGroupOnHover; }
+    ILxQtPanel * panel() const { return mPlugin->panel(); }
 
 public slots:
     void settingsChanged();

--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -441,7 +441,8 @@ void LxQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     KWindowInfo info(mWindow, 0, NET::WM2AllowedActions);
     unsigned long state = KWindowInfo(mWindow, NET::WMState).state();
 
-    QMenu menu(tr("Application"));
+    QMenu * menu = new QMenu(tr("Application"));
+    menu->setAttribute(Qt::WA_DeleteOnClose);
     QAction* a;
 
     /* KDE menu *******
@@ -474,7 +475,7 @@ void LxQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     if (deskNum > 1)
     {
         int winDesk = KWindowInfo(mWindow, NET::WMDesktop).desktop();
-        QMenu* deskMenu = menu.addMenu(tr("To &Desktop"));
+        QMenu* deskMenu = menu->addMenu(tr("To &Desktop"));
 
         a = deskMenu->addAction(tr("&All Desktops"));
         a->setData(NET::OnAllDesktops);
@@ -491,58 +492,58 @@ void LxQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
         }
 
         int curDesk = KWindowSystem::currentDesktop();
-        a = menu.addAction(tr("&To Current Desktop"));
+        a = menu->addAction(tr("&To Current Desktop"));
         a->setData(curDesk);
         a->setEnabled(curDesk != winDesk);
         connect(a, SIGNAL(triggered(bool)), this, SLOT(moveApplicationToDesktop()));
     }
 
     /********** State menu **********/
-    menu.addSeparator();
+    menu->addSeparator();
 
-    a = menu.addAction(tr("Ma&ximize"));
+    a = menu->addAction(tr("Ma&ximize"));
     a->setEnabled(info.actionSupported(NET::ActionMax) && (!(state & NET::Max) || (state & NET::Hidden)));
     a->setData(NET::Max);
     connect(a, SIGNAL(triggered(bool)), this, SLOT(maximizeApplication()));
 
     if (event->modifiers() & Qt::ShiftModifier)
     {
-        a = menu.addAction(tr("Maximize vertically"));
+        a = menu->addAction(tr("Maximize vertically"));
         a->setEnabled(info.actionSupported(NET::ActionMaxVert) && !((state & NET::MaxVert) || (state & NET::Hidden)));
         a->setData(NET::MaxVert);
         connect(a, SIGNAL(triggered(bool)), this, SLOT(maximizeApplication()));
 
-        a = menu.addAction(tr("Maximize horizontally"));
+        a = menu->addAction(tr("Maximize horizontally"));
         a->setEnabled(info.actionSupported(NET::ActionMaxHoriz) && !((state & NET::MaxHoriz) || (state & NET::Hidden)));
         a->setData(NET::MaxHoriz);
         connect(a, SIGNAL(triggered(bool)), this, SLOT(maximizeApplication()));
     }
 
-    a = menu.addAction(tr("&Restore"));
+    a = menu->addAction(tr("&Restore"));
     a->setEnabled((state & NET::Hidden) || (state & NET::Max) || (state & NET::MaxHoriz) || (state & NET::MaxVert));
     connect(a, SIGNAL(triggered(bool)), this, SLOT(deMaximizeApplication()));
 
-    a = menu.addAction(tr("Mi&nimize"));
+    a = menu->addAction(tr("Mi&nimize"));
     a->setEnabled(info.actionSupported(NET::ActionMinimize) && !(state & NET::Hidden));
     connect(a, SIGNAL(triggered(bool)), this, SLOT(minimizeApplication()));
 
     if (state & NET::Shaded)
     {
-        a = menu.addAction(tr("Roll down"));
+        a = menu->addAction(tr("Roll down"));
         a->setEnabled(info.actionSupported(NET::ActionShade) && !(state & NET::Hidden));
         connect(a, SIGNAL(triggered(bool)), this, SLOT(unShadeApplication()));
     }
     else
     {
-        a = menu.addAction(tr("Roll up"));
+        a = menu->addAction(tr("Roll up"));
         a->setEnabled(info.actionSupported(NET::ActionShade) && !(state & NET::Hidden));
         connect(a, SIGNAL(triggered(bool)), this, SLOT(shadeApplication()));
     }
 
     /********** Layer menu **********/
-    menu.addSeparator();
+    menu->addSeparator();
 
-    QMenu* layerMenu = menu.addMenu(tr("&Layer"));
+    QMenu* layerMenu = menu->addMenu(tr("&Layer"));
 
     a = layerMenu->addAction(tr("Always on &top"));
     // FIXME: There is no info.actionSupported(NET::ActionKeepAbove)
@@ -563,10 +564,11 @@ void LxQtTaskButton::contextMenuEvent(QContextMenuEvent* event)
     connect(a, SIGNAL(triggered(bool)), this, SLOT(setApplicationLayer()));
 
     /********** Kill menu **********/
-    menu.addSeparator();
-    a = menu.addAction(XdgIcon::fromTheme("process-stop"), tr("&Close"));
+    menu->addSeparator();
+    a = menu->addAction(XdgIcon::fromTheme("process-stop"), tr("&Close"));
     connect(a, SIGNAL(triggered(bool)), this, SLOT(closeApplication()));
-    menu.exec(mapToGlobal(event->pos()));
+    menu->setGeometry(mParentTaskBar->panel()->calculatePopupWindowPos(mapToGlobal(event->pos()), menu->sizeHint()));
+    menu->show();
 }
 
 /************************************************

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -76,11 +76,15 @@ void LxQtTaskGroup::contextMenuEvent(QContextMenuEvent *event)
         return;
     }
 
-    QMenu menu(tr("Group"));
-    QAction *a = menu.addAction(XdgIcon::fromTheme("process-stop"), tr("Close group"));
+    QMenu * menu = new QMenu(tr("Group"));
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    QAction *a = menu->addAction(XdgIcon::fromTheme("process-stop"), tr("Close group"));
     connect(a, SIGNAL(triggered()), this, SLOT(closeGroup()));
-    menu.exec(mapToGlobal(event->pos()));
-    mPreventPopup = false;
+    connect(menu, &QMenu::aboutToHide, [this] {
+        mPreventPopup = false;
+    });
+    menu->setGeometry(mPlugin->panel()->calculatePopupWindowPos(mapToGlobal(event->pos()), menu->sizeHint()));
+    menu->show();
 }
 
 /************************************************


### PR DESCRIPTION
fixes lxde/lxqt#613

There is still problem if the menu has more levels (as in taskbar) -> the second level is also not aligned as expected to the previous level.... 