### PR TITLE
Kbd state indicator, settings dialog, fixed small issues

### DIFF
--- a/plugin-kbindicator/src/content.cpp
+++ b/plugin-kbindicator/src/content.cpp
@@ -37,6 +37,7 @@ Content::Content(bool layoutEnabled):
     m_layout->setAlignment(Qt::AlignCenter);
     m_layout->installEventFilter(this);
     layout()->addWidget(m_layout);
+    m_layout->setEnabled(false);
 }
 
 Content::~Content()

--- a/plugin-kbindicator/src/kbdstateconfig.cpp
+++ b/plugin-kbindicator/src/kbdstateconfig.cpp
@@ -14,7 +14,7 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
     connect(m_ui->showCaps,   &QCheckBox::clicked, this, &KbdStateConfig::save);
     connect(m_ui->showNum,    &QCheckBox::clicked, this, &KbdStateConfig::save);
     connect(m_ui->showScroll, &QCheckBox::clicked, this, &KbdStateConfig::save);
-    connect(m_ui->showLayout, &QCheckBox::clicked, this, &KbdStateConfig::save);
+    connect(m_ui->showLayout, &QGroupBox::clicked, this, &KbdStateConfig::save);
 
     connect(m_ui->modes, static_cast<void (QButtonGroup::*)(int)>(&QButtonGroup::buttonClicked),
         [this](int){
@@ -22,11 +22,11 @@ KbdStateConfig::KbdStateConfig(QWidget *parent) :
         }
     );
 
-    connect(m_ui->showLayout, &QCheckBox::stateChanged, [this](int checked){
-        //m_ui->showFlags->setEnabled(checked); //TODO: Country flags support
-        m_ui->switchGlobal->setEnabled(checked);
-        m_ui->switchWindow->setEnabled(checked);
-        m_ui->switchApplication->setEnabled(checked);
+    connect(m_ui->btns, &QDialogButtonBox::clicked, [this](QAbstractButton *btn){
+        if (m_ui->btns->buttonRole(btn) == QDialogButtonBox::ResetRole){
+            Settings::instance().restore();
+            load();
+        }
     });
 
     connect(m_ui->configureLayouts, &QPushButton::clicked, this, &KbdStateConfig::configureLayouts);

--- a/plugin-kbindicator/src/kbdstateconfig.ui
+++ b/plugin-kbindicator/src/kbdstateconfig.ui
@@ -7,17 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>249</width>
-    <height>390</height>
+    <height>354</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Keyboard state settings</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="QGroupBox" name="leds">
      <property name="title">
-      <string>Leds</string>
+      <string>Lock Indicators</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
@@ -45,73 +45,26 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="switchMode">
+    <widget class="QGroupBox" name="showLayout">
      <property name="title">
-      <string/>
+      <string>Keyboard Layout Indicator</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="showLayout">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="text">
-           <string>Show keyboard layout</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="showFlags">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+       <widget class="QLabel" name="policyLabel">
         <property name="text">
-         <string>Show flags instead labels</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Layout mode:</string>
+         <string>Switching policy</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QRadioButton" name="switchGlobal">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="text">
          <string>Global</string>
         </property>
@@ -122,9 +75,6 @@
       </item>
       <item>
        <widget class="QRadioButton" name="switchWindow">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="text">
          <string>Window</string>
         </property>
@@ -135,9 +85,6 @@
       </item>
       <item>
        <widget class="QRadioButton" name="switchApplication">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
         <property name="text">
          <string>Application</string>
         </property>
@@ -146,14 +93,14 @@
         </attribute>
        </widget>
       </item>
-      <item>
-       <widget class="QPushButton" name="configureLayouts">
-        <property name="text">
-         <string>Configure layouts</string>
-        </property>
-       </widget>
-      </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="configureLayouts">
+     <property name="text">
+      <string>Configure layouts</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -175,7 +122,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>

--- a/plugin-kbindicator/src/settings.cpp
+++ b/plugin-kbindicator/src/settings.cpp
@@ -11,7 +11,10 @@ Settings & Settings::instance()
 }
 
 void Settings::init(QSettings *settings)
-{ m_settings = settings; }
+{
+    m_settings = settings;
+    m_oldSettings.reset(new LxQt::SettingsCache(settings));
+}
 
 bool Settings::showCapLock() const
 { return m_settings->value("show_caps_lock", true).toBool(); }
@@ -39,7 +42,7 @@ void Settings::setShowLayout(bool show)
 
 KeeperType Settings::keeperType() const
 {
-    QString type = m_settings->value("keeper_type", "application").toString();
+    QString type = m_settings->value("keeper_type", "global").toString();
     if(type == "global")
         return KeeperType::Global;
     if(type == "window")
@@ -63,3 +66,6 @@ void Settings::setKeeperType(KeeperType type) const
         break;
     }
 }
+
+void Settings::restore()
+{ m_oldSettings->loadToSettings(); }

--- a/plugin-kbindicator/src/settings.h
+++ b/plugin-kbindicator/src/settings.h
@@ -1,6 +1,7 @@
 #ifndef _SETTINGS_H_
 #define _SETTINGS_H_
 
+#include <LXQt/Settings>
 class QSettings;
 
 enum class KeeperType
@@ -24,6 +25,7 @@ public:
     bool showScrollLock() const;
     bool showLayout() const;
     KeeperType keeperType() const;
+    void restore();
 public:
     void setShowCapLock(bool show);
     void setShowNumLock(bool show);
@@ -31,7 +33,8 @@ public:
     void setShowLayout(bool show);
     void setKeeperType(KeeperType type) const;
 private:
-    QSettings *m_settings = 0;
+    QSettings                           *m_settings = 0;
+    QScopedPointer<LxQt::SettingsCache>  m_oldSettings;
 };
 
 #endif

--- a/plugin-kbindicator/src/x11/kbdlayout.cpp
+++ b/plugin-kbindicator/src/x11/kbdlayout.cpp
@@ -85,6 +85,7 @@ public:
 
                 if(sevent->changed & XCB_XKB_STATE_PART_GROUP_STATE){
                     emit m_pub->layoutChanged(sevent->group);
+                    return true;
                 }
 
                 if(sevent->changed & XCB_XKB_STATE_PART_MODIFIER_LOCK){
@@ -105,6 +106,7 @@ public:
         }
 
         emit m_pub->checkState();
+
         return false;
     }
 


### PR DESCRIPTION
This PR fixes lxde/lxqt#735, lxde/lxqt#730, lxde/lxqt#732 and probably lxde/lxqt#731
Settings now looks like:
![conf](https://cloud.githubusercontent.com/assets/550431/8994796/c4de1ae4-370d-11e5-9cd5-56d6c660f20a.png)

But i don't know and cannot find why label is orange, anybody knows? :)