### PR TITLE
Notifier fixes

### DIFF
--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -36,7 +36,7 @@
 
 StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, ILXQtPanelPlugin* plugin, QWidget *parent)
     : QToolButton(parent),
-    mMenu(NULL),
+    mMenu(nullptr),
     mStatus(Passive),
     mValid(true),
     mFallbackIcon(QIcon::fromTheme("application-x-executable")),
@@ -75,6 +75,7 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
 
 StatusNotifierButton::~StatusNotifierButton()
 {
+    delete interface;
 }
 
 void StatusNotifierButton::newIcon()
@@ -221,7 +222,7 @@ void StatusNotifierButton::mouseReleaseEvent(QMouseEvent *event)
         interface->Activate(QCursor::pos().x(), QCursor::pos().y());
     else if (event->button() == Qt::MidButton)
         interface->SecondaryActivate(QCursor::pos().x(), QCursor::pos().y());
-    else if (Qt::RightButton == event->button())
+    else if (Qt::RightButton == event->button() && nullptr != mMenu)
         mMenu->popup(QCursor::pos());
     QToolButton::mouseReleaseEvent(event);
 }

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -53,6 +53,11 @@ StatusNotifierWidget::StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *pa
 
 }
 
+StatusNotifierWidget::~StatusNotifierWidget()
+{
+    delete mWatcher;
+}
+
 void StatusNotifierWidget::itemAdded(QString serviceAndPath)
 {
     int slash = serviceAndPath.indexOf('/');

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -60,20 +60,26 @@ StatusNotifierWidget::~StatusNotifierWidget()
 
 void StatusNotifierWidget::itemAdded(QString serviceAndPath)
 {
-    int slash = serviceAndPath.indexOf('/');
-    QString serv = serviceAndPath.left(slash);
-    QString path = serviceAndPath.mid(slash);
-    StatusNotifierButton *button = new StatusNotifierButton(serv, path, mPlugin, this);
+    //postpone the logic to not block DBus response
+    //XXX: 200ms is because some application (e.g. quassel) doesn't respond to our
+    //queries (Title, Menu, Id...) until it gets response for it's IsStatusNotifierHostRegistered
+    //Which in turn is not responded from our side if we are quering the application.
+    QTimer::singleShot(200, [this, serviceAndPath] () {
+        int slash = serviceAndPath.indexOf('/');
+        QString serv = serviceAndPath.left(slash);
+        QString path = serviceAndPath.mid(slash);
+        StatusNotifierButton *button = new StatusNotifierButton(serv, path, mPlugin, this);
 
-    if (!button->isValid())
-        delete button;
-    else
-    {
-        mServices.insert(serviceAndPath, button);
-        layout()->addWidget(button);
-        layout()->setAlignment(button, Qt::AlignCenter);
-        button->show();
-    }
+        if (!button->isValid())
+            delete button;
+        else
+        {
+            mServices.insert(serviceAndPath, button);
+            layout()->addWidget(button);
+            layout()->setAlignment(button, Qt::AlignCenter);
+            button->show();
+        }
+    });
 }
 
 void StatusNotifierWidget::itemRemoved(const QString &serviceAndPath)

--- a/plugin-statusnotifier/statusnotifierwidget.h
+++ b/plugin-statusnotifier/statusnotifierwidget.h
@@ -42,6 +42,7 @@ class StatusNotifierWidget : public QWidget
 
 public:
     StatusNotifierWidget(ILXQtPanelPlugin *plugin, QWidget *parent = 0);
+    ~StatusNotifierWidget();
 
 signals:
 


### PR DESCRIPTION
This PR handles:
- correct disposal of objects (avoid memory leaks, make correct unregistration of org.kde.StatusNotfierWatcher on DBus)
- checking for existence of menu (avoid SEGFAULT crash)
- postpone new item registration logic (avoid deadlock/timeout for registering of some clients)