### PR TITLE
Replace QPixmap::grabWindow with QScreen's version

### DIFF
--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -28,6 +28,7 @@
 #include "colorpicker.h"
 #include <QMouseEvent>
 #include <QHBoxLayout>
+#include <QScreen>
 
 
 ColorPicker::ColorPicker(const ILXQtPanelPluginStartupInfo &startupInfo) :
@@ -82,7 +83,7 @@ void ColorPickerWidget::mouseReleaseEvent(QMouseEvent *event)
         return;
 
     WId id = QApplication::desktop()->winId();
-    QPixmap pixmap = QPixmap::grabWindow(id, event->globalX(), event->globalY(), 1, 1);
+    QPixmap pixmap = qApp->primaryScreen()->grabWindow(id, event->globalX(), event->globalY(), 1, 1);
 
     QImage img = pixmap.toImage();
     QColor col = QColor(img.pixel(0,0));

--- a/plugin-tray/trayicon.cpp
+++ b/plugin-tray/trayicon.cpp
@@ -33,6 +33,7 @@
 #include <QPainter>
 #include <QBitmap>
 #include <QStyle>
+#include <QScreen>
 
 #include "../panel/lxqtpanel.h"
 #include "trayicon.h"
@@ -311,8 +312,8 @@ void TrayIcon::draw(QPaintEvent* /*event*/)
 
         XClearArea(mDisplay, (Window)winId(), 0, 0, attr.width, attr.height, False);
         // for some unknown reason, XGetImage failed. try another less efficient method.
-        // QPixmap::grabWindow uses XCopyArea() internally.
-        image = QPixmap::grabWindow(mIconId).toImage();
+        // QScreen::grabWindow uses XCopyArea() internally.
+        image = qApp->primaryScreen()->grabWindow(mIconId).toImage();
     }
 
 //    qDebug() << "Paint icon **************************************";


### PR DESCRIPTION
Qt has deprecated QPixmap::grabWindow, which is still used in the color picker and systray plugins. This commit replaces these calls with the new QScreen::grabWindow.

Fixes lxde/lxqt#826.
Fixes lxde/lxqt#827.