### PR TITLE
Make panel's settings private for more reliability

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -35,7 +35,6 @@
 #include "popupmenu.h"
 #include "plugin.h"
 #include "panelpluginsmodel.h"
-#include <LXQt/Settings>
 #include <LXQt/PluginInfo>
 
 #include <QScreen>
@@ -112,8 +111,9 @@ QString LXQtPanel::positionToStr(ILXQtPanel::Position position)
 /************************************************
 
  ************************************************/
-LXQtPanel::LXQtPanel(const QString &configGroup, QWidget *parent) :
+LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidget *parent) :
     QFrame(parent),
+    mSettings(settings),
     mConfigGroup(configGroup),
     mPlugins{nullptr},
     mPanelSize(0),
@@ -175,8 +175,6 @@ LXQtPanel::LXQtPanel(const QString &configGroup, QWidget *parent) :
     connect(LXQt::Settings::globalSettings(), SIGNAL(settingsChanged()), this, SLOT(update()));
     connect(lxqtApp, SIGNAL(themeChanged()), this, SLOT(realign()));
 
-    LXQtPanelApplication *app = reinterpret_cast<LXQtPanelApplication*>(qApp);
-    mSettings = app->settings();
     readSettings();
     // the old position might be on a visible screen
     ensureVisible();

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -33,6 +33,7 @@
 #include <QString>
 #include <QTimer>
 #include <QPointer>
+#include <LXQt/Settings>
 #include "ilxqtpanel.h"
 #include "lxqtpanelglobals.h"
 
@@ -59,6 +60,8 @@ class LXQT_PANEL_API LXQtPanel : public QFrame, public ILXQtPanel
     // for configuration dialog
     friend class ConfigPanelWidget;
     friend class ConfigPluginsWidget;
+    friend class ConfigPanelDialog;
+    friend class PanelPluginsModel;
 
 public:
     enum Alignment {
@@ -67,7 +70,7 @@ public:
         AlignmentRight  =  1
     };
 
-    LXQtPanel(const QString &configGroup, QWidget *parent = 0);
+    LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidget *parent = 0);
     virtual ~LXQtPanel();
 
     QString name() { return mConfigGroup; }
@@ -103,8 +106,6 @@ public:
     QString backgroundImage() const { return mBackgroundImage; };
     int opacity() const { return mOpacity; };
     bool hidable() const { return mHidable; }
-
-    LXQt::Settings *settings() const { return mSettings; }
 
     bool isPluginSingletonAndRunnig(QString const & pluginId) const;
 
@@ -142,6 +143,7 @@ protected:
 
 public slots:
     void showConfigDialog();
+
 private slots:
     void showAddPluginDialog();
     void realign();
@@ -188,6 +190,9 @@ private:
     QPointer<ConfigPanelDialog> mConfigDialog;
 
     void updateStyleSheet();
+
+    // settings should be kept private for security
+    LXQt::Settings *settings() const { return mSettings; }
 };
 
 

--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -107,11 +107,11 @@ void LXQtPanelApplication::addNewPanel()
 
 LXQtPanel* LXQtPanelApplication::addPanel(const QString& name)
 {
-    LXQtPanel *panel = new LXQtPanel(name);
+    LXQtPanel *panel = new LXQtPanel(name, mSettings);
     mPanels << panel;
-    connect(panel, SIGNAL(deletedByUser(LXQtPanel*)),
-            this, SLOT(removePanel(LXQtPanel*)));
-    //reemit signals
+
+    // reemit signals
+    connect(panel, &LXQtPanel::deletedByUser, this, &LXQtPanelApplication::removePanel);
     connect(panel, &LXQtPanel::pluginAdded, this, &LXQtPanelApplication::pluginAdded);
     connect(panel, &LXQtPanel::pluginRemoved, this, &LXQtPanelApplication::pluginRemoved);
 

--- a/panel/lxqtpanelapplication.h
+++ b/panel/lxqtpanelapplication.h
@@ -47,7 +47,6 @@ public:
     ~LXQtPanelApplication();
 
     int count() { return mPanels.count(); }
-    LXQt::Settings *settings() { return mSettings; }
     bool isPluginSingletonAndRunnig(QString const & pluginId) const;
 
 public slots:


### PR DESCRIPTION
Any plugin can simply do: `reinterpret_cast<LxQtPanelApplication *>(qApp)->settings()` and put in question the panel's settings' reliability.

See discussion in lxde/lxqt#443.