### PR TITLE
Fix #839 - lxqt-panel plugins enumeration

### DIFF
--- a/panel/panelpluginsmodel.cpp
+++ b/panel/panelpluginsmodel.cpp
@@ -246,9 +246,12 @@ QString PanelPluginsModel::findNewPluginSettingsGroup(const QString &pluginType)
     groups.sort();
 
     // Generate new section name
-    for (int i = 2; true; ++i)
-        if (!groups.contains(QStringLiteral("%1%2").arg(pluginType).arg(i)))
-            return QStringLiteral("%1%2").arg(pluginType).arg(i);
+    if (!groups.contains(QStringLiteral("%1").arg(pluginType)))
+        return QStringLiteral("%1").arg(pluginType);
+    else
+        for (int i = 2; true; ++i)
+            if (!groups.contains(QStringLiteral("%1%2").arg(pluginType).arg(i)))
+                return QStringLiteral("%1%2").arg(pluginType).arg(i);
 }
 
 void PanelPluginsModel::onActivatedIndex(QModelIndex const & index)


### PR DESCRIPTION
In method <tt>PanelPluginsModel::findNewPluginSettingsGroup()</tt> we check first
if there is an instance of the plugin so that we don&rsquo;t start enumerating
plugins from number two when unwarranted.