### PR TITLE
WIP: taskbar: add Meta+1..9 shortcuts to raise windows

### DIFF
--- a/plugin-taskbar/CMakeLists.txt
+++ b/plugin-taskbar/CMakeLists.txt
@@ -24,6 +24,7 @@ set(UIS
 
 set(LIBRARIES
     lxqt
+    lxqt-globalkeys
     Qt5Xdg
 )
 

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -672,11 +672,18 @@ void LXQtTaskBar::shortcutRegistered()
 
 void LXQtTaskBar::activateTask(int pos)
 {
-    if (pos < mLayout->count())
+    for (int i = 1; i < mLayout->count(); ++i)
     {
-        QWidget * o = mLayout->itemAt(pos)->widget();
+        QWidget * o = mLayout->itemAt(i)->widget();
         LXQtTaskGroup * g = qobject_cast<LXQtTaskGroup *>(o);
-        if (g)
-            g->raiseApplication();
+		if (g && g->isVisible())
+		{
+			pos--;
+			if (pos == 0)
+			{
+				g->raiseApplication();
+				break;
+			}
+		}
     }
 }

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -56,7 +56,7 @@ using namespace LXQt;
 ************************************************/
 LXQtTaskBar::LXQtTaskBar(ILXQtPanelPlugin *plugin, QWidget *parent) :
     QFrame(parent),
-    m_pSignalMapper(new QSignalMapper(this)),
+    mSignalMapper(new QSignalMapper(this)),
     mButtonStyle(Qt::ToolButtonTextBesideIcon),
     mCloseOnMiddleClick(true),
     mRaiseOnCurrentDesktop(true),
@@ -87,8 +87,8 @@ LXQtTaskBar::LXQtTaskBar(ILXQtPanelPlugin *plugin, QWidget *parent) :
     QTimer::singleShot(0, this, SLOT(settingsChanged()));
     setAcceptDrops(true);
 
-    connect (m_pSignalMapper, SIGNAL(mapped(int)), this, SLOT(activateTask(int)));
-    QTimer::singleShot(0, this, SLOT(registerShortcuts()));
+    connect(mSignalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &LXQtTaskBar::activateTask);
+    QTimer::singleShot(0, this, &LXQtTaskBar::registerShortcuts);
 
     connect(KWindowSystem::self(), SIGNAL(stackingOrderChanged()), SLOT(refreshTaskList()));
     connect(KWindowSystem::self(), static_cast<void (KWindowSystem::*)(WId, NET::Properties, NET::Properties2)>(&KWindowSystem::windowChanged)
@@ -644,10 +644,10 @@ void LXQtTaskBar::registerShortcuts()
 
         if (nullptr != gshortcut)
         {
-            m_keys << gshortcut;
+            mKeys << gshortcut;
             connect(gshortcut, &GlobalKeyShortcut::Action::registrationFinished, this, &LXQtTaskBar::shortcutRegistered);
-            connect(gshortcut, SIGNAL(activated()), m_pSignalMapper, SLOT(map()));
-            m_pSignalMapper->setMapping(gshortcut, i);
+            connect(gshortcut, &GlobalKeyShortcut::Action::activated, mSignalMapper, static_cast<void (QSignalMapper::*)()>(&QSignalMapper::map));
+            mSignalMapper->setMapping(gshortcut, i);
         }
     }
 }
@@ -658,7 +658,7 @@ void LXQtTaskBar::shortcutRegistered()
 
     disconnect(shortcut, &GlobalKeyShortcut::Action::registrationFinished, this, &LXQtTaskBar::shortcutRegistered);
 
-    const int i = m_keys.indexOf(shortcut);
+    const int i = mKeys.indexOf(shortcut);
     Q_ASSERT(-1 != i);
 
     if (shortcut->shortcut().isEmpty())

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -630,13 +630,15 @@ void LXQtTaskBar::changeEvent(QEvent* event)
 void LXQtTaskBar::registerShortcuts()
 {
     // Register shortcuts to switch to the task
+    // mPlaceHolder is always at position 0
+    // tasks are at positions 1..10
     GlobalKeyShortcut::Action * gshortcut;
     QString path;
     QString description;
-    for (int i = 0; i < 10; ++i)
+    for (int i = 1; i <= 10; ++i)
     {
-        path = QString("/panel/%1/task_%2").arg(mPlugin->settings()->group()).arg(i + 1);
-        description = tr("Activate task %1").arg(i + 1);
+        path = QString("/panel/%1/task_%2").arg(mPlugin->settings()->group()).arg(i);
+        description = tr("Activate task %1").arg(i);
 
         gshortcut = GlobalKeyShortcut::Client::instance()->addAction(QStringLiteral(), path, description, this);
 
@@ -661,23 +663,20 @@ void LXQtTaskBar::shortcutRegistered()
 
     if (shortcut->shortcut().isEmpty())
     {
-        shortcut->changeShortcut(QStringLiteral("Meta+%1").arg(i + 1));
+        // Shortcuts come in order they were registered
+        // starting from index 0
+        const int key = (i + 1) % 10;
+        shortcut->changeShortcut(QStringLiteral("Meta+%1").arg(key));
     }
 }
 
 void LXQtTaskBar::activateTask(int pos)
 {
-    for (int i = 0; i < mLayout->count(); i++)
+    if (pos < mLayout->count())
     {
-        QWidget * o = mLayout->itemAt(i)->widget();
+        QWidget * o = mLayout->itemAt(pos)->widget();
         LXQtTaskGroup * g = qobject_cast<LXQtTaskGroup *>(o);
-        if (!g)
-            continue;
-        if(pos == 0)
-        {
+        if (g)
             g->raiseApplication();
-            break;
-        }
-        pos--;        
     }
 }

--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -676,14 +676,14 @@ void LXQtTaskBar::activateTask(int pos)
     {
         QWidget * o = mLayout->itemAt(i)->widget();
         LXQtTaskGroup * g = qobject_cast<LXQtTaskGroup *>(o);
-		if (g && g->isVisible())
-		{
-			pos--;
-			if (pos == 0)
-			{
-				g->raiseApplication();
-				break;
-			}
-		}
+        if (g && g->isVisible())
+        {
+            pos--;
+            if (pos == 0)
+            {
+                g->raiseApplication();
+                break;
+            }
+        }
     }
 }

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -42,11 +42,13 @@
 #include <QFrame>
 #include <QBoxLayout>
 #include <QMap>
+#include <lxqt-globalkeys.h>
 #include "../panel/ilxqtpanel.h"
 #include <KWindowSystem/KWindowSystem>
 #include <KWindowSystem/KWindowInfo>
 #include <KWindowSystem/NETWM>
 
+class QSignalMapper;
 class LXQtTaskButton;
 class ElidedButtonStyle;
 
@@ -95,6 +97,7 @@ protected:
     virtual void dragMoveEvent(QDragMoveEvent * event);
 
 private slots:
+    void shortcutRegistered();
     void refreshTaskList();
     void refreshButtonRotation();
     void refreshPlaceholderVisibility();
@@ -102,6 +105,8 @@ private slots:
     void onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2);
     void onWindowAdded(WId window);
     void onWindowRemoved(WId window);
+    void activateTask(int pos);
+    void registerShortcuts();
 
 private:
     typedef QMap<WId, LXQtTaskGroup*> windowMap_t;
@@ -114,6 +119,8 @@ private:
 private:
     QMap<WId, LXQtTaskGroup*> mKnownWindows; //!< Ids of known windows (mapping to buttons/groups)
     LXQt::GridLayout *mLayout;
+    QList<GlobalKeyShortcut::Action*> m_keys;
+    QSignalMapper* m_pSignalMapper;
 
     // Settings
     Qt::ToolButtonStyle mButtonStyle;

--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -97,7 +97,6 @@ protected:
     virtual void dragMoveEvent(QDragMoveEvent * event);
 
 private slots:
-    void shortcutRegistered();
     void refreshTaskList();
     void refreshButtonRotation();
     void refreshPlaceholderVisibility();
@@ -105,8 +104,9 @@ private slots:
     void onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2);
     void onWindowAdded(WId window);
     void onWindowRemoved(WId window);
-    void activateTask(int pos);
     void registerShortcuts();
+    void shortcutRegistered();
+    void activateTask(int pos);
 
 private:
     typedef QMap<WId, LXQtTaskGroup*> windowMap_t;
@@ -119,8 +119,8 @@ private:
 private:
     QMap<WId, LXQtTaskGroup*> mKnownWindows; //!< Ids of known windows (mapping to buttons/groups)
     LXQt::GridLayout *mLayout;
-    QList<GlobalKeyShortcut::Action*> m_keys;
-    QSignalMapper* m_pSignalMapper;
+    QList<GlobalKeyShortcut::Action*> mKeys;
+    QSignalMapper *mSignalMapper;
 
     // Settings
     Qt::ToolButtonStyle mButtonStyle;


### PR DESCRIPTION
Hi LXQt developers!
I have added shortcuts to raise applications with Meta+number keys. Actually the code is mostly copypaste from `plugin-desktopswitch` and it possibly doesn't work as expected with grouped applications.
For me this "windows7 like" dock feature is vital. So if you are interested in such contribution I will put my efforts to enhance the code further.

Also I am dreaming about the ability to pin launcher as well, but it is much harder to implement.
