### PR TITLE
mainmenu: Fix close menu by "weird" shortcut

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.h
+++ b/plugin-mainmenu/lxqtmainmenu.h
@@ -97,7 +97,6 @@ private:
 
     QTimer mDelayedPopup;
     QTimer mHideTimer;
-    QKeySequence mShortcutSeq;
     QString mMenuFile;
 
 protected slots:
@@ -108,7 +107,6 @@ protected slots:
 private slots:
     void showMenu();
     void showHideMenu();
-    void shortcutChanged(const QString &oldShortcut, const QString &newShortcut);
 };
 
 class LXQtMainMenuPluginLibrary: public QObject, public ILXQtPanelPluginLibrary


### PR DESCRIPTION
Globalkeys uses not compatible string representation of shortcut (it's probably done by KeysymToString)
with QKeySequence. So we are not able to know if the shortcut sequence was pressed in event handling.
We use a workaround and closing the menu after any "modifier" key pushed (this way also other QMenu objects behave)

references lxde/lxqt#859