### PR TITLE
volume: Handle add/removal of pulse sink correcly

### DIFF
--- a/plugin-volume/lxqtvolume.h
+++ b/plugin-volume/lxqtvolume.h
@@ -62,7 +62,7 @@ public:
     void setAudioEngine(AudioEngine *engine);
 protected slots:
     virtual void settingsChanged();
-    void updateConfigurationSinkList();
+    void handleSinkListChanged();
     void handleShortcutVolumeUp();
     void handleShortcutVolumeDown();
     void handleShortcutVolumeMute();

--- a/plugin-volume/pulseaudioengine.h
+++ b/plugin-volume/pulseaudioengine.h
@@ -56,7 +56,8 @@ public:
 
     int volumeMax(AudioDevice */*device*/) const { return m_maximumVolume; }
 
-    void requestSinkInfoUpdate(AudioDevice *device);
+    void requestSinkInfoUpdate(uint32_t idx);
+    void removeSink(uint32_t idx);
     void addOrUpdateSink(const pa_sink_info *info);
 
     pa_context_state_t contextState() const { return m_contextState; }
@@ -65,13 +66,13 @@ public:
 
 public slots:
     void commitDeviceVolume(AudioDevice *device);
-    void retrieveSinkInfo(AudioDevice *device);
+    void retrieveSinkInfo(uint32_t idx);
     void setMute(AudioDevice *device, bool state);
     void setContextState(pa_context_state_t state);
     void setIgnoreMaxVolume(bool ignore);
 
 signals:
-    void sinkInfoChanged(AudioDevice *device);
+    void sinkInfoChanged(uint32_t idx);
     void contextStateChanged(pa_context_state_t state);
     void readyChanged(bool ready);
 


### PR DESCRIPTION
The add/removal of sink in pulse wasn't handled at all -> the supporing
logic was added into pulse engine.

Setting the default sink in volume plugin was also broken (after
number of sinks changed, the default wasn't correctly restored).

This should be the solution for unusability of plugin-volume for case when pulse sinks are added/removed (e.g. adding/removing hotplug audio device).

@jleclanche I wasn't able to find the issue for this. I was trying to simulate, what you had told yesterday on IRC, by enabling/disabling devices .