### PR TITLE
desktop-switch: Hightlight only windows that are in the taskbar as well

### DIFF
--- a/plugin-desktopswitch/desktopswitch.h
+++ b/plugin-desktopswitch/desktopswitch.h
@@ -86,6 +86,7 @@ private:
     DesktopSwitchButton::LabelType mLabelType;
 
     void refresh();
+    bool isWindowHighlightable(WId window);
 
 private slots:
     void setDesktop(int desktop);


### PR DESCRIPTION
Sometimes a button of the desktop-switch plugin gets hightlighted, but its correspondent window is not in the taskbar plugin. Now the same filter that is applied in the taskbar will be applied in desktop-switch.