### PR TITLE
worldclock: Decrease (unnecessary) wake-ups

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -46,7 +46,6 @@ LXQtWorldClock::LXQtWorldClock(const ILXQtPanelPluginStartupInfo &startupInfo):
     mPopup(NULL),
     mTimer(new QTimer(this)),
     mUpdateInterval(1),
-    mLastUpdate(0),
     mAutoRotate(true),
     mPopupContent(NULL)
 {
@@ -67,6 +66,7 @@ LXQtWorldClock::LXQtWorldClock(const ILXQtPanelPluginStartupInfo &startupInfo):
 
     settingsChanged();
 
+    mTimer->setTimerType(Qt::PreciseTimer);
     connect(mTimer, SIGNAL(timeout()), SLOT(timeout()));
 
     connect(mContent, SIGNAL(wheelScrolled(int)), SLOT(wheelScrolled(int)));
@@ -79,28 +79,35 @@ LXQtWorldClock::~LXQtWorldClock()
 
 void LXQtWorldClock::timeout()
 {
+    if (QDateTime{}.time().msec() > 500)
+        restartTimer();
+    setTimeText();
+}
+
+void LXQtWorldClock::setTimeText()
+{
     QDateTime now = QDateTime::currentDateTime();
-    qint64 nowMsec = now.toMSecsSinceEpoch();
-    if ((mLastUpdate / mUpdateInterval) == (nowMsec / mUpdateInterval))
-        return;
-
-    mLastUpdate = nowMsec;
-
     QString timeZoneName = mActiveTimeZone;
     if (timeZoneName == QLatin1String("local"))
         timeZoneName = QString::fromLatin1(QTimeZone::systemTimeZoneId());
 
-    mContent->setText(formatDateTime(now, timeZoneName));
-
-    mRotatedWidget->update();
-
-    updatePopupContent();
+    QString time_text = formatDateTime(now, timeZoneName);
+    if (mContent->text() != time_text)
+    {
+        mContent->setText(time_text);
+        mRotatedWidget->update();
+        updatePopupContent();
+    }
 }
 
-void LXQtWorldClock::restartTimer(int updateInterval)
+void LXQtWorldClock::restartTimer()
 {
-    mUpdateInterval = updateInterval;
-    mTimer->start(qMin(100, updateInterval));
+    mTimer->stop();
+    mTimer->setInterval(mUpdateInterval);
+
+    int delay = static_cast<int>((mUpdateInterval - (static_cast<long long>(QTime::currentTime().msecsSinceStartOfDay()) % mUpdateInterval)) % mUpdateInterval);
+    QTimer::singleShot(delay, Qt::PreciseTimer, [this] { setTimeText(); });
+    QTimer::singleShot(delay, Qt::PreciseTimer, mTimer, SLOT(start()));
 }
 
 void LXQtWorldClock::settingsChanged()
@@ -264,18 +271,19 @@ void LXQtWorldClock::settingsChanged()
 
     if ((oldFormat != mFormat))
     {
-        int updateInterval = 0;
-
+        int update_interval;
         QString format = mFormat;
         format.replace(QRegExp(QLatin1String("'[^']*'")), QString());
-        if (format.contains(QLatin1String("z")))
-            updateInterval = 1;
-        else if (format.contains(QLatin1String("s")))
-            updateInterval = 1000;
+        //don't support updating on milisecond basis -> big performance hit
+        if (format.contains(QLatin1String("s")))
+            update_interval = 1000;
+        else if (format.contains(QLatin1String("m")))
+            update_interval = 60000;
         else
-            updateInterval = 60000;
+            update_interval = 3600000;
 
-        restartTimer(updateInterval);
+        if (update_interval != mUpdateInterval)
+            restartTimer();
     }
 
     bool autoRotate = settings()->value(QLatin1String("autoRotate"), true).toBool();
@@ -292,7 +300,7 @@ void LXQtWorldClock::settingsChanged()
         mPopup->setGeometry(calculatePopupWindowPos(mPopup->size()));
     }
 
-    timeout();
+    setTimeText();
 }
 
 QDialog *LXQtWorldClock::configureDialog()
@@ -305,7 +313,7 @@ void LXQtWorldClock::wheelScrolled(int delta)
     if (mTimeZones.count() > 1)
     {
         mActiveTimeZone = mTimeZones[(mTimeZones.indexOf(mActiveTimeZone) + ((delta > 0) ? -1 : 1) + mTimeZones.size()) % mTimeZones.size()];
-        timeout();
+        setTimeText();
     }
 }
 

--- a/plugin-worldclock/lxqtworldclock.h
+++ b/plugin-worldclock/lxqtworldclock.h
@@ -75,7 +75,6 @@ private:
 
     QTimer *mTimer;
     int mUpdateInterval;
-    qint64 mLastUpdate;
 
     QStringList mTimeZones;
     QMap<QString, QString> mTimeZoneCustomNames;
@@ -86,12 +85,13 @@ private:
     bool mAutoRotate;
     QLabel *mPopupContent;
 
-    void restartTimer(int);
+    void restartTimer();
 
     QString formatDateTime(const QDateTime &datetime, const QString &timeZoneName);
     void updatePopupContent();
     bool formatHasTimeZone(QString format);
     QString preformat(const QString &format, const QTimeZone &timeZone, const QDateTime& dateTime);
+    void setTimeText();
 };
 
 

--- a/plugin-worldclock/lxqtworldclockconfigurationmanualformat.ui
+++ b/plugin-worldclock/lxqtworldclockconfigurationmanualformat.ui
@@ -115,7 +115,7 @@
 &lt;tr&gt;&lt;td&gt;TTTT&lt;/td&gt;&lt;td&gt;the timezone short display name&lt;/td&gt;&lt;/tr&gt;
 &lt;tr&gt;&lt;td&gt;TTTTT&lt;/td&gt;&lt;td&gt;the timezone long display name&lt;/td&gt;&lt;/tr&gt;
 &lt;tr&gt;&lt;td&gt;TTTTTT&lt;/td&gt;&lt;td&gt;the timezone custom name. You can change it the 'Time zones' tab of the configuration window&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;
-&lt;p&gt;&lt;br /&gt;&lt;b&gt;Note:&lt;/b&gt; Any characters in the pattern that are not in the ranges of ['a'..'z'] and ['A'..'Z'] will be treated as quoted text. For instance, characters like ':', '.', ' ', '#' and '@' will appear in the resulting time text even they are not enclosed within single quotes.The single quote is used to 'escape' letters. Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.&lt;/p&gt;
+&lt;br /&gt;&lt;b&gt;Notes:&lt;/b&gt; &lt;ul&gt;&lt;li&gt;Any characters in the pattern that are not in the ranges of ['a'..'z'] and ['A'..'Z'] will be treated as quoted text. For instance, characters like ':', '.', ' ', '#' and '@' will appear in the resulting time text even they are not enclosed within single quotes.The single quote is used to 'escape' letters. Two single quotes in a row, whether inside or outside a quoted sequence, represent a 'real' single quote.&lt;/li&gt;&lt;li&gt;Minimal update interval is 1 second. If z or zzz is configured time is shown with the milliseconds fraction, but not updated on millisecond basis (avoiding big performance hit).&lt;/li&gt;&lt;ul&gt;
 </string>
           </property>
           <property name="textFormat">


### PR DESCRIPTION
Logic changed from "wake-up at least each 100ms and check if there is something to do"
to "wake-up precisely and do what is needed" by use of Qt::PreciseTimer (as in @3af690c).

closes lxde/lxqt#873