### PR TITLE
Include sources which export used functions

### DIFF
--- a/plugin-mount/CMakeLists.txt
+++ b/plugin-mount/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADERS
 )
 
 set(SOURCES
+    ${PROJECT_SOURCE_DIR}/panel/lxqtpanelpluginconfigdialog.cpp
     lxqtmountplugin.cpp
     configuration.cpp
     button.cpp


### PR DESCRIPTION
It seems that this is needed on my system to compile without any
errors/warnings.
Patch is provided by hrvoje.senjan@gmail.com.

Please review this.