### PR TITLE
panel: Fill background

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -154,6 +154,7 @@ LXQtPanel::LXQtPanel(const QString &configGroup, LXQt::Settings *settings, QWidg
 
     LXQtPanelWidget = new QFrame(this);
     LXQtPanelWidget->setObjectName("BackgroundWidget");
+    LXQtPanelWidget->setAutoFillBackground(true);
     QGridLayout* lav = new QGridLayout();
     lav->setMargin(0);
     setLayout(lav);


### PR DESCRIPTION
Auto filling background is needed for "System" a.k.a. "No Theme"

ref. lxde/lxqt#892