### PR TITLE
Enable Vim code completion through the YCM plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 *.kdev4
 CMakeLists.txt.user
+.ycm_extra_conf.py*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+# generate json used for code completion
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)


### PR DESCRIPTION
Switching CMAKE_EXPORT_COMPILER_COMMANDS on tells CMake to ask clang to export compilation information useful for code completion. This is how Vim's YCM works.

@luis-pereira IIRC you use vim. What do you think of this?