### PR TITLE
Remove redundant code from many plugins' configuration classes

### DIFF
--- a/panel/lxqtpanelpluginconfigdialog.h
+++ b/panel/lxqtpanelpluginconfigdialog.h
@@ -40,7 +40,8 @@ class LXQT_PANEL_API LXQtPanelPluginConfigDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit LXQtPanelPluginConfigDialog(QSettings &settings, QWidget *parent = 0);
+    explicit LXQtPanelPluginConfigDialog(QSettings &settings, QWidget *parent = nullptr);
+    explicit LXQtPanelPluginConfigDialog(QSettings *settings, QWidget *parent = nullptr) : LXQtPanelPluginConfigDialog(*settings, parent) {}
     virtual ~LXQtPanelPluginConfigDialog();
 
     QSettings& settings() const;

--- a/plugin-clock/lxqtclock.cpp
+++ b/plugin-clock/lxqtclock.cpp
@@ -301,7 +301,7 @@ void LXQtClock::activated(ActivationReason reason)
 
 QDialog * LXQtClock::configureDialog()
 {
-     return new LXQtClockConfiguration(*settings());
+     return new LXQtClockConfiguration(settings());
 }
 
 bool LXQtClock::eventFilter(QObject *watched, QEvent *event)

--- a/plugin-clock/lxqtclockconfiguration.cpp
+++ b/plugin-clock/lxqtclockconfiguration.cpp
@@ -75,11 +75,9 @@ namespace
     };
 }
 
-LXQtClockConfiguration::LXQtClockConfiguration(QSettings &settings, QWidget *parent) :
-    QDialog(parent),
+LXQtClockConfiguration::LXQtClockConfiguration(QSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtClockConfiguration),
-    mSettings(settings),
-    oldSettings(settings),
     mOldIndex(1)
 {
     setAttribute(Qt::WA_DeleteOnClose);
@@ -205,21 +203,21 @@ void LXQtClockConfiguration::loadSettings()
     QString systemDateLocale = QLocale::system().dateFormat(QLocale::ShortFormat).toUpper();
     QString systemTimeLocale = QLocale::system().timeFormat(QLocale::ShortFormat).toUpper();
 
-    QString timeFormat = mSettings.value("timeFormat", systemTimeLocale.contains("AP") ? "h:mm AP" : "HH:mm").toString();
+    QString timeFormat = settings().value("timeFormat", systemTimeLocale.contains("AP") ? "h:mm AP" : "HH:mm").toString();
 
     ui->showSecondsCB->setChecked(timeFormat.indexOf("ss") > -1);
 
     ui->ampmClockCB->setChecked(timeFormat.toUpper().indexOf("AP") > -1);
 
-    ui->useUtcCB->setChecked(mSettings.value("UTC", false).toBool());
+    ui->useUtcCB->setChecked(settings().value("UTC", false).toBool());
 
     ui->dontShowDateRB->setChecked(true);
-    ui->showDateBeforeTimeRB->setChecked(mSettings.value("showDate", "no").toString().toLower() == "before");
-    ui->showDateAfterTimeRB->setChecked(mSettings.value("showDate", "no").toString().toLower() == "after");
-    ui->showDateBelowTimeRB->setChecked(mSettings.value("showDate", "no").toString().toLower() == "below");
+    ui->showDateBeforeTimeRB->setChecked(settings().value("showDate", "no").toString().toLower() == "before");
+    ui->showDateAfterTimeRB->setChecked(settings().value("showDate", "no").toString().toLower() == "after");
+    ui->showDateBelowTimeRB->setChecked(settings().value("showDate", "no").toString().toLower() == "below");
 
-    mCustomDateFormat = mSettings.value("customDateFormat", QString()).toString();
-    QString dateFormat = mSettings.value("dateFormat", QLocale::system().dateFormat(QLocale::ShortFormat)).toString();
+    mCustomDateFormat = settings().value("customDateFormat", QString()).toString();
+    QString dateFormat = settings().value("dateFormat", QLocale::system().dateFormat(QLocale::ShortFormat)).toString();
 
     createDateFormats();
 
@@ -233,8 +231,8 @@ void LXQtClockConfiguration::loadSettings()
     }
     mOldIndex = ui->dateFormatCOB->currentIndex();
 
-    ui->autorotateCB->setChecked(mSettings.value("autoRotate", true).toBool());
-    ui->firstDayOfWeekCB->setCurrentIndex(dynamic_cast<FirstDayCombo&>(*(ui->firstDayOfWeekCB->model())).findIndex(mSettings.value("firstDayOfWeek", -1).toInt()));
+    ui->autorotateCB->setChecked(settings().value("autoRotate", true).toBool());
+    ui->firstDayOfWeekCB->setCurrentIndex(dynamic_cast<FirstDayCombo&>(*(ui->firstDayOfWeekCB->model())).findIndex(settings().value("firstDayOfWeek", -1).toInt()));
 }
 
 void LXQtClockConfiguration::saveSettings()
@@ -244,36 +242,23 @@ void LXQtClockConfiguration::saveSettings()
     if (ui->showSecondsCB->isChecked())
         timeFormat.insert(timeFormat.indexOf("mm") + 2, ":ss");
 
-    mSettings.setValue("timeFormat", timeFormat);
+    settings().setValue("timeFormat", timeFormat);
 
-    mSettings.setValue("UTC", ui->useUtcCB->isChecked());
+    settings().setValue("UTC", ui->useUtcCB->isChecked());
 
-    mSettings.setValue("showDate",
+    settings().setValue("showDate",
         ui->showDateBeforeTimeRB->isChecked() ? "before" :
         (ui->showDateAfterTimeRB->isChecked() ? "after" :
         (ui->showDateBelowTimeRB->isChecked() ? "below" : "no" )));
 
-    mSettings.setValue("customDateFormat", mCustomDateFormat);
+    settings().setValue("customDateFormat", mCustomDateFormat);
     if (ui->dateFormatCOB->currentIndex() == (ui->dateFormatCOB->count() - 1))
-        mSettings.setValue("dateFormat", mCustomDateFormat);
+        settings().setValue("dateFormat", mCustomDateFormat);
     else
-        mSettings.setValue("dateFormat", ui->dateFormatCOB->itemData(ui->dateFormatCOB->currentIndex()));
+        settings().setValue("dateFormat", ui->dateFormatCOB->itemData(ui->dateFormatCOB->currentIndex()));
 
-    mSettings.setValue("autoRotate", ui->autorotateCB->isChecked());
-    mSettings.setValue("firstDayOfWeek", dynamic_cast<QStandardItemModel&>(*ui->firstDayOfWeekCB->model()).item(ui->firstDayOfWeekCB->currentIndex(), 0)->data(Qt::UserRole));
-}
-
-void LXQtClockConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        oldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
+    settings().setValue("autoRotate", ui->autorotateCB->isChecked());
+    settings().setValue("firstDayOfWeek", dynamic_cast<QStandardItemModel&>(*ui->firstDayOfWeekCB->model()).item(ui->firstDayOfWeekCB->currentIndex(), 0)->data(Qt::UserRole));
 }
 
 void LXQtClockConfiguration::dateFormatActivated(int index)

--- a/plugin-clock/lxqtclockconfiguration.h
+++ b/plugin-clock/lxqtclockconfiguration.h
@@ -29,30 +29,27 @@
 #ifndef LXQTCLOCKCONFIGURATION_H
 #define LXQTCLOCKCONFIGURATION_H
 
-#include <QDialog>
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include <LXQt/Settings>
 #include <QAbstractButton>
 #include <QButtonGroup>
 #include <QLocale>
 #include <QDateTime>
 
-#include <LXQt/Settings>
-
 namespace Ui {
     class LXQtClockConfiguration;
 }
 
-class LXQtClockConfiguration : public QDialog
+class LXQtClockConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtClockConfiguration(QSettings &settings, QWidget *parent = 0);
+    explicit LXQtClockConfiguration(QSettings *settings, QWidget *parent = 0);
     ~LXQtClockConfiguration();
 
 private:
     Ui::LXQtClockConfiguration *ui;
-    QSettings &mSettings;
-    LXQt::SettingsCache oldSettings;
 
     /*
       Read settings from conf file and put data into controls.
@@ -69,7 +66,6 @@ private slots:
       Saves settings in conf file.
     */
     void saveSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
     void dateFormatActivated(int);
 
 private:

--- a/plugin-cpuload/lxqtcpuloadconfiguration.cpp
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.cpp
@@ -34,10 +34,8 @@
 #define BAR_ORIENT_RIGHTLEFT "rightLeft"
 
 LXQtCpuLoadConfiguration::LXQtCpuLoadConfiguration(QSettings *settings, QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::LXQtCpuLoadConfiguration),
-    mSettings(settings),
-    mOldSettings(settings)
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::LXQtCpuLoadConfiguration)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("CpuLoadConfigurationWindow");
@@ -75,54 +73,40 @@ void LXQtCpuLoadConfiguration::fillBarOrientations()
 
 void LXQtCpuLoadConfiguration::loadSettings()
 {
-    ui->showTextCB->setChecked(mSettings->value("showText", false).toBool());
-    ui->barWidthSB->setValue(mSettings->value("barWidth", 20).toInt());
-    ui->updateIntervalSpinBox->setValue(mSettings->value("updateInterval", 1000).toInt() / 1000.0);
+    ui->showTextCB->setChecked(settings().value("showText", false).toBool());
+    ui->barWidthSB->setValue(settings().value("barWidth", 20).toInt());
+    ui->updateIntervalSpinBox->setValue(settings().value("updateInterval", 1000).toInt() / 1000.0);
 
     int boIndex = ui->barOrientationCOB->findData(
-            mSettings->value("barOrientation", BAR_ORIENT_BOTTOMUP));
+            settings().value("barOrientation", BAR_ORIENT_BOTTOMUP));
     boIndex = (boIndex < 0) ? 1 : boIndex;
     ui->barOrientationCOB->setCurrentIndex(boIndex);
 
-//	QString menuFile = mSettings->value("menu_file", "").toString();
+//	QString menuFile = settings().value("menu_file", "").toString();
 //	if (menuFile.isEmpty())
 //	{
 //		menuFile = XdgMenu::getMenuFileName();
 //	}
 //	ui->menuFilePathLE->setText(menuFile);
-//	ui->shortcutEd->setKeySequence(mSettings->value("shortcut", "Alt+F1").toString());
+//	ui->shortcutEd->setKeySequence(settings().value("shortcut", "Alt+F1").toString());
 }
 
 void LXQtCpuLoadConfiguration::showTextChanged(bool value)
 {
-    mSettings->setValue("showText", value);
+    settings().setValue("showText", value);
 }
 
 void LXQtCpuLoadConfiguration::barWidthChanged(int value)
 {
-    mSettings->setValue("barWidth", value);
+    settings().setValue("barWidth", value);
 }
 
 void LXQtCpuLoadConfiguration::updateIntervalChanged(double value)
 {
-    mSettings->setValue("updateInterval", value*1000);
+    settings().setValue("updateInterval", value*1000);
 }
 
 void LXQtCpuLoadConfiguration::barOrientationChanged(int index)
 {
-    mSettings->setValue("barOrientation", ui->barOrientationCOB->itemData(index).toString());
+    settings().setValue("barOrientation", ui->barOrientationCOB->itemData(index).toString());
 }
-
-void LXQtCpuLoadConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
-}
-

--- a/plugin-cpuload/lxqtcpuloadconfiguration.h
+++ b/plugin-cpuload/lxqtcpuloadconfiguration.h
@@ -29,9 +29,8 @@
 #ifndef LXQTCPULOADCONFIGURATION_H
 #define LXQTCPULOADCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 
 class QSettings;
 class QAbstractButton;
@@ -40,18 +39,16 @@ namespace Ui {
     class LXQtCpuLoadConfiguration;
 }
 
-class LXQtCpuLoadConfiguration : public QDialog
+class LXQtCpuLoadConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtCpuLoadConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit LXQtCpuLoadConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtCpuLoadConfiguration();
 
 private:
     Ui::LXQtCpuLoadConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache mOldSettings;
 
     /*
       Fills Bar orientation combobox
@@ -63,7 +60,6 @@ private slots:
       Saves settings in conf file.
     */
     void loadSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
     void showTextChanged(bool value);
     void barWidthChanged(int value);
     void updateIntervalChanged(double value);

--- a/plugin-desktopswitch/desktopswitchconfiguration.cpp
+++ b/plugin-desktopswitch/desktopswitchconfiguration.cpp
@@ -29,11 +29,9 @@
 #include <KWindowSystem>
 #include <QTimer>
 
-DesktopSwitchConfiguration::DesktopSwitchConfiguration(QSettings *settings, QWidget *parent)
-    : QDialog(parent)
-    , ui(new Ui::DesktopSwitchConfiguration)
-    , mSettings(settings)
-    , mOldSettings(settings)
+DesktopSwitchConfiguration::DesktopSwitchConfiguration(QSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::DesktopSwitchConfiguration)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("DesktopSwitchConfigurationWindow");
@@ -56,8 +54,8 @@ DesktopSwitchConfiguration::~DesktopSwitchConfiguration()
 
 void DesktopSwitchConfiguration::loadSettings()
 {
-    ui->rowsSB->setValue(mSettings->value("rows", 1).toInt());
-    ui->labelTypeCB->setCurrentIndex(mSettings->value("labelType", 0).toInt());
+    ui->rowsSB->setValue(settings().value("rows", 1).toInt());
+    ui->labelTypeCB->setCurrentIndex(settings().value("labelType", 0).toInt());
 }
 
 void DesktopSwitchConfiguration::loadDesktopsNames()
@@ -79,24 +77,11 @@ void DesktopSwitchConfiguration::loadDesktopsNames()
 
 void DesktopSwitchConfiguration::rowsChanged(int value)
 {
-    mSettings->setValue("rows", value);
+    settings().setValue("rows", value);
 }
 
 void DesktopSwitchConfiguration::labelTypeChanged(int type)
 {
-    mSettings->setValue("labelType", type);
-}
-
-void DesktopSwitchConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
+    settings().setValue("labelType", type);
 }
 

--- a/plugin-desktopswitch/desktopswitchconfiguration.h
+++ b/plugin-desktopswitch/desktopswitchconfiguration.h
@@ -28,9 +28,8 @@
 #ifndef DESKTOPSWITCHCERCONFIGURATION_H
 #define DESKTOPSWITCHCERCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 #include <QFormLayout>
 #include <QLineEdit>
 
@@ -41,18 +40,16 @@ namespace Ui {
     class DesktopSwitchConfiguration;
 }
 
-class DesktopSwitchConfiguration : public QDialog
+class DesktopSwitchConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit DesktopSwitchConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit DesktopSwitchConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~DesktopSwitchConfiguration();
 
 private:
     Ui::DesktopSwitchConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache mOldSettings;
 
 private slots:
     /*
@@ -60,7 +57,6 @@ private slots:
     */
     void loadSettings();
     void loadDesktopsNames();
-    void dialogButtonsAction(QAbstractButton *btn);
     void rowsChanged(int value);
     void labelTypeChanged(int type);
 };

--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -168,7 +168,7 @@ void DirectoryMenu::addActions(QMenu* menu, const QString& path)
 
 QDialog* DirectoryMenu::configureDialog()
 {
-     return new DirectoryMenuConfiguration(*settings());
+     return new DirectoryMenuConfiguration(settings());
 }
 
 void DirectoryMenu::settingsChanged()

--- a/plugin-directorymenu/directorymenuconfiguration.cpp
+++ b/plugin-directorymenu/directorymenuconfiguration.cpp
@@ -38,11 +38,9 @@
 #include "ui_directorymenuconfiguration.h"
 
 
-DirectoryMenuConfiguration::DirectoryMenuConfiguration(QSettings &settings, QWidget *parent) :
-    QDialog(parent),
+DirectoryMenuConfiguration::DirectoryMenuConfiguration(QSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::DirectoryMenuConfiguration),
-    mSettings(settings),
-    mOldSettings(settings),
     mBaseDirectory(QDir::homePath()),
     mDefaultIcon(XdgIcon::fromTheme("folder"))
 {
@@ -66,10 +64,10 @@ DirectoryMenuConfiguration::~DirectoryMenuConfiguration()
 
 void DirectoryMenuConfiguration::loadSettings()
 {
-    mBaseDirectory.setPath(mSettings.value("baseDirectory", QDir::homePath()).toString());
+    mBaseDirectory.setPath(settings().value("baseDirectory", QDir::homePath()).toString());
     ui->baseDirectoryB->setText(mBaseDirectory.dirName());
 
-    mIcon = mSettings.value("icon", QString()).toString();
+    mIcon = settings().value("icon", QString()).toString();
     if(!mIcon.isNull())
     {
         QIcon buttonIcon = QIcon(mIcon);
@@ -85,21 +83,8 @@ void DirectoryMenuConfiguration::loadSettings()
 
 void DirectoryMenuConfiguration::saveSettings()
 {
-    mSettings.setValue("baseDirectory", mBaseDirectory.absolutePath());
-    mSettings.setValue("icon", mIcon);
-}
-
-void DirectoryMenuConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
+    settings().setValue("baseDirectory", mBaseDirectory.absolutePath());
+    settings().setValue("icon", mIcon);
 }
 
 void DirectoryMenuConfiguration::showDirectoryDialog()

--- a/plugin-directorymenu/directorymenuconfiguration.h
+++ b/plugin-directorymenu/directorymenuconfiguration.h
@@ -30,31 +30,28 @@
 #ifndef DIRECTORYMENUCONFIGURATION_H
 #define DIRECTORYMENUCONFIGURATION_H
 
-#include <QDialog>
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include <LXQt/Settings>
 #include <QAbstractButton>
 #include <QButtonGroup>
 #include <QLocale>
 #include <QDateTime>
 #include <QDir>
 
-#include <LXQt/Settings>
-
 namespace Ui {
     class DirectoryMenuConfiguration;
 }
 
-class DirectoryMenuConfiguration : public QDialog
+class DirectoryMenuConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit DirectoryMenuConfiguration(QSettings &settings, QWidget *parent = 0);
+    explicit DirectoryMenuConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~DirectoryMenuConfiguration();
 
 private:
     Ui::DirectoryMenuConfiguration *ui;
-    QSettings &mSettings;
-    LXQt::SettingsCache mOldSettings;
     QDir mBaseDirectory;
     QString mIcon;
     QIcon mDefaultIcon;
@@ -69,7 +66,6 @@ private slots:
       Saves settings in conf file.
     */
     void saveSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
     void showDirectoryDialog();
     void showIconDialog();
 

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -273,7 +273,7 @@ void LXQtMainMenu::setMenuFontSize()
  ************************************************/
 QDialog *LXQtMainMenu::configureDialog()
 {
-    return new LXQtMainMenuConfiguration(*settings(), mShortcut, DEFAULT_SHORTCUT);
+    return new LXQtMainMenuConfiguration(settings(), mShortcut, DEFAULT_SHORTCUT);
 }
 /************************************************
 

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.cpp
@@ -34,11 +34,9 @@
 
 #include <QFileDialog>
 
-LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(QSettings &settings, GlobalKeyShortcut::Action * shortcut, const QString &defaultShortcut, QWidget *parent) :
-    QDialog(parent),
+LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(QSettings *settings, GlobalKeyShortcut::Action * shortcut, const QString &defaultShortcut, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtMainMenuConfiguration),
-    mSettings(settings),
-    mOldSettings(settings),
     mDefaultShortcut(defaultShortcut),
     mShortcut(shortcut)
 {
@@ -57,14 +55,14 @@ LXQtMainMenuConfiguration::LXQtMainMenuConfiguration(QSettings &settings, Global
     connect(ui->showTextCB, SIGNAL(toggled(bool)), this, SLOT(showTextChanged(bool)));
     connect(ui->textLE, SIGNAL(textEdited(QString)), this, SLOT(textButtonChanged(QString)));
     connect(ui->chooseMenuFilePB, SIGNAL(clicked()), this, SLOT(chooseMenuFile()));
-    connect(ui->menuFilePathLE, &QLineEdit::textChanged, [this] (QString const & file)
+    connect(ui->menuFilePathLE, &QLineEdit::textChanged, [&] (QString const & file)
         {
-            mSettings.setValue(QLatin1String("menu_file"), file);
+            this->settings().setValue(QLatin1String("menu_file"), file);
         });
     connect(ui->iconPB, &QAbstractButton::clicked, this, &LXQtMainMenuConfiguration::chooseIcon);
-    connect(ui->iconLE, &QLineEdit::textChanged, [this] (QString const & path)
+    connect(ui->iconLE, &QLineEdit::textChanged, [&] (QString const & path)
         {
-            mSettings.setValue(QLatin1String("icon"), path);
+            this->settings().setValue(QLatin1String("icon"), path);
         });
 
     connect(ui->shortcutEd, SIGNAL(shortcutGrabbed(QString)), this, SLOT(shortcutChanged(QString)));
@@ -83,11 +81,11 @@ LXQtMainMenuConfiguration::~LXQtMainMenuConfiguration()
 
 void LXQtMainMenuConfiguration::loadSettings()
 {
-    ui->iconLE->setText(mSettings.value("icon", QLatin1String(LXQT_GRAPHICS_DIR"/helix.svg")).toString());
-    ui->showTextCB->setChecked(mSettings.value("showText", false).toBool());
-    ui->textLE->setText(mSettings.value("text", "").toString());
+    ui->iconLE->setText(settings().value("icon", QLatin1String(LXQT_GRAPHICS_DIR"/helix.svg")).toString());
+    ui->showTextCB->setChecked(settings().value("showText", false).toBool());
+    ui->textLE->setText(settings().value("text", "").toString());
 
-    QString menuFile = mSettings.value("menu_file", "").toString();
+    QString menuFile = settings().value("menu_file", "").toString();
     if (menuFile.isEmpty())
     {
         menuFile = XdgMenu::getMenuFileName();
@@ -95,24 +93,24 @@ void LXQtMainMenuConfiguration::loadSettings()
     ui->menuFilePathLE->setText(menuFile);
     ui->shortcutEd->setText(nullptr != mShortcut ? mShortcut->shortcut() : mDefaultShortcut);
 
-    ui->customFontCB->setChecked(mSettings.value("customFont", false).toBool());
+    ui->customFontCB->setChecked(settings().value("customFont", false).toBool());
     LXQt::Settings lxqtSettings("lxqt"); //load system font size as init value
     QFont systemFont;
     lxqtSettings.beginGroup(QLatin1String("Qt"));
     systemFont.fromString(lxqtSettings.value("font", this->font()).toString());
     lxqtSettings.endGroup();
-    ui->customFontSizeSB->setValue(mSettings.value("customFontSize", systemFont.pointSize()).toInt());
+    ui->customFontSizeSB->setValue(settings().value("customFontSize", systemFont.pointSize()).toInt());
 }
 
 
 void LXQtMainMenuConfiguration::textButtonChanged(const QString &value)
 {
-    mSettings.setValue("text", value);
+    settings().setValue("text", value);
 }
 
 void LXQtMainMenuConfiguration::showTextChanged(bool value)
 {
-    mSettings.setValue("showText", value);
+    settings().setValue("showText", value);
 }
 
 void LXQtMainMenuConfiguration::chooseIcon()
@@ -159,25 +157,12 @@ void LXQtMainMenuConfiguration::shortcutReset()
     shortcutChanged(mDefaultShortcut);
 }
 
-void LXQtMainMenuConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
-}
-
 void LXQtMainMenuConfiguration::customFontChanged(bool value)
 {
-    mSettings.setValue("customFont", value);
+    settings().setValue("customFont", value);
 }
 
 void LXQtMainMenuConfiguration::customFontSizeChanged(int value)
 {
-    mSettings.setValue("customFontSize", value);
+    settings().setValue("customFontSize", value);
 }

--- a/plugin-mainmenu/lxqtmainmenuconfiguration.h
+++ b/plugin-mainmenu/lxqtmainmenuconfiguration.h
@@ -29,9 +29,8 @@
 #ifndef LXQTMAINMENUCONFIGURATION_H
 #define LXQTMAINMENUCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 
 class QSettings;
 class QAbstractButton;
@@ -44,18 +43,19 @@ namespace GlobalKeyShortcut {
     class Action;
 }
 
-class LXQtMainMenuConfiguration : public QDialog
+class LXQtMainMenuConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtMainMenuConfiguration(QSettings &settings, GlobalKeyShortcut::Action * shortcut, const QString &defaultShortcut, QWidget *parent = 0);
+    explicit LXQtMainMenuConfiguration(QSettings *settings,
+                                          GlobalKeyShortcut::Action *shortcut,
+                                          const QString &defaultShortcut,
+                                          QWidget *parent = nullptr);
     ~LXQtMainMenuConfiguration();
 
 private:
     Ui::LXQtMainMenuConfiguration *ui;
-    QSettings &mSettings;
-    LXQt::SettingsCache mOldSettings;
     QString mDefaultShortcut;
     GlobalKeyShortcut::Action * mShortcut;
 
@@ -66,7 +66,6 @@ private slots:
       Saves settings in conf file.
     */
     void loadSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
     void textButtonChanged(const QString &value);
     void showTextChanged(bool value);
     void chooseIcon();

--- a/plugin-mount/configuration.cpp
+++ b/plugin-mount/configuration.cpp
@@ -32,7 +32,7 @@
 #include <QComboBox>
 #include <QDialogButtonBox>
 
-Configuration::Configuration(QSettings &settings, QWidget *parent) :
+Configuration::Configuration(QSettings *settings, QWidget *parent) :
     LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::Configuration)
 {

--- a/plugin-mount/configuration.h
+++ b/plugin-mount/configuration.h
@@ -44,7 +44,7 @@ class Configuration : public LXQtPanelPluginConfigDialog
     Q_OBJECT
 
 public:
-    explicit Configuration(QSettings &settings, QWidget *parent = 0);
+    explicit Configuration(QSettings *settings, QWidget *parent = 0);
     ~Configuration();
 
 protected slots:

--- a/plugin-mount/lxqtmountplugin.cpp
+++ b/plugin-mount/lxqtmountplugin.cpp
@@ -54,7 +54,7 @@ QDialog *LXQtMountPlugin::configureDialog()
     if (mPopup)
         mPopup->hide();
 
-    Configuration *configWindow = new Configuration(*settings());
+    Configuration *configWindow = new Configuration(settings());
     configWindow->setAttribute(Qt::WA_DeleteOnClose, true);
     return configWindow;
 }

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.cpp
@@ -39,10 +39,8 @@ extern "C" {
 #endif
 
 LXQtNetworkMonitorConfiguration::LXQtNetworkMonitorConfiguration(QSettings *settings, QWidget *parent) :
-    QDialog(parent),
-    ui(new Ui::LXQtNetworkMonitorConfiguration),
-    mSettings(settings),
-    mOldSettings(settings)
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::LXQtNetworkMonitorConfiguration)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("NetworkMonitorConfigurationWindow");
@@ -62,13 +60,13 @@ LXQtNetworkMonitorConfiguration::~LXQtNetworkMonitorConfiguration()
 
 void LXQtNetworkMonitorConfiguration::saveSettings()
 {
-    mSettings->setValue("icon", ui->iconCB->currentIndex());
-    mSettings->setValue("interface", ui->interfaceCB->currentText());
+    settings().setValue("icon", ui->iconCB->currentIndex());
+    settings().setValue("interface", ui->interfaceCB->currentText());
 }
 
 void LXQtNetworkMonitorConfiguration::loadSettings()
 {
-    ui->iconCB->setCurrentIndex(mSettings->value("icon", 1).toInt());
+    ui->iconCB->setCurrentIndex(settings().value("icon", 1).toInt());
 
     int count;
 #ifdef STATGRAB_NEWER_THAN_0_90
@@ -81,20 +79,6 @@ void LXQtNetworkMonitorConfiguration::loadSettings()
     for (int ix = 0; ix < count; ix++)
         ui->interfaceCB->addItem(stats[ix].interface_name);
 
-    QString interface = mSettings->value("interface").toString();
+    QString interface = settings().value("interface").toString();
     ui->interfaceCB->setCurrentIndex(qMax(qMin(0, count - 1), ui->interfaceCB->findText(interface)));
 }
-
-void LXQtNetworkMonitorConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-    {
-        close();
-    }
-}
-

--- a/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.h
+++ b/plugin-networkmonitor/lxqtnetworkmonitorconfiguration.h
@@ -29,9 +29,8 @@
 #ifndef LXQTNETWORKMONITORCONFIGURATION_H
 #define LXQTNETWORKMONITORCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 
 class QSettings;
 class QAbstractButton;
@@ -41,18 +40,16 @@ namespace Ui
 class LXQtNetworkMonitorConfiguration;
 }
 
-class LXQtNetworkMonitorConfiguration : public QDialog
+class LXQtNetworkMonitorConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtNetworkMonitorConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit LXQtNetworkMonitorConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtNetworkMonitorConfiguration();
 
 private:
     Ui::LXQtNetworkMonitorConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache mOldSettings;
 
 private slots:
     /*
@@ -60,7 +57,6 @@ private slots:
     */
     void saveSettings();
     void loadSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
 };
 
 #endif // LXQTNETWORKMONITORCONFIGURATION_H

--- a/plugin-sensors/lxqtsensorsconfiguration.h
+++ b/plugin-sensors/lxqtsensorsconfiguration.h
@@ -28,30 +28,27 @@
 #ifndef LXQTSENSORSCONFIGURATION_H
 #define LXQTSENSORSCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
+#include <LXQt/Settings>
 #include <QAbstractButton>
 #include <QButtonGroup>
 #include <QDateTime>
-#include <QDialog>
 #include <QLocale>
-#include <LXQt/Settings>
-
 
 namespace Ui {
     class LXQtSensorsConfiguration;
 }
 
-class LXQtSensorsConfiguration : public QDialog
+class LXQtSensorsConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtSensorsConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit LXQtSensorsConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtSensorsConfiguration();
 
 private:
     Ui::LXQtSensorsConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache oldSettings;
 
     /*
       Read settings from conf file and put data into controls.
@@ -63,7 +60,6 @@ private slots:
       Saves settings in conf file.
     */
     void saveSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
     void changeProgressBarColor();
     void detectedChipSelected(int index);
 };

--- a/plugin-spacer/spacerconfiguration.cpp
+++ b/plugin-spacer/spacerconfiguration.cpp
@@ -36,10 +36,9 @@ const QStringList SpacerConfiguration::msTypes = {
     , QLatin1String(QT_TR_NOOP("invisible"))
 };
 
-SpacerConfiguration::SpacerConfiguration(QSettings *settings, QWidget *parent)
-    : QDialog(parent)
-    , ui(new Ui::SpacerConfiguration)
-    , mSettings(settings)
+SpacerConfiguration::SpacerConfiguration(QSettings *settings, QWidget *parent) :
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::SpacerConfiguration)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("SpacerConfigurationWindow");
@@ -62,16 +61,16 @@ SpacerConfiguration::~SpacerConfiguration()
 
 void SpacerConfiguration::loadSettings()
 {
-    ui->sizeSB->setValue(mSettings->value("size", 8).toInt());
-    ui->typeCB->setCurrentIndex(ui->typeCB->findData(mSettings->value("spaceType", msTypes[0]).toString()));
+    ui->sizeSB->setValue(settings().value("size", 8).toInt());
+    ui->typeCB->setCurrentIndex(ui->typeCB->findData(settings().value("spaceType", msTypes[0]).toString()));
 }
 
 void SpacerConfiguration::sizeChanged(int value)
 {
-    mSettings->setValue("size", value);
+    settings().setValue("size", value);
 }
 
 void SpacerConfiguration::typeChanged(int index)
 {
-    mSettings->setValue("spaceType", ui->typeCB->itemData(index, Qt::UserRole));
+    settings().setValue("spaceType", ui->typeCB->itemData(index, Qt::UserRole));
 }

--- a/plugin-spacer/spacerconfiguration.h
+++ b/plugin-spacer/spacerconfiguration.h
@@ -28,9 +28,8 @@
 #ifndef SPACERCONFIGURATION_H
 #define SPACERCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 
 class QSettings;
 class QAbstractButton;
@@ -39,12 +38,12 @@ namespace Ui {
     class SpacerConfiguration;
 }
 
-class SpacerConfiguration : public QDialog
+class SpacerConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit SpacerConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit SpacerConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~SpacerConfiguration();
 
 public:
@@ -52,7 +51,6 @@ public:
 
 private:
     Ui::SpacerConfiguration *ui;
-    QSettings *mSettings;
 
 private slots:
     /*

--- a/plugin-sysstat/lxqtsysstatconfiguration.cpp
+++ b/plugin-sysstat/lxqtsysstatconfiguration.cpp
@@ -84,10 +84,8 @@ namespace
 }
 
 LXQtSysStatConfiguration::LXQtSysStatConfiguration(QSettings *settings, QWidget *parent) :
-    QDialog(parent),
+    LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtSysStatConfiguration),
-    mSettings(settings),
-    oldSettings(settings),
     mStat(NULL),
     mColoursDialog(NULL)
 {
@@ -119,27 +117,27 @@ LXQtSysStatConfiguration::~LXQtSysStatConfiguration()
 
 void LXQtSysStatConfiguration::loadSettings()
 {
-    ui->intervalSB->setValue(mSettings->value("graph/updateInterval", 1.0).toDouble());
-    ui->sizeSB->setValue(mSettings->value("graph/minimalSize", 30).toInt());
+    ui->intervalSB->setValue(settings().value("graph/updateInterval", 1.0).toDouble());
+    ui->sizeSB->setValue(settings().value("graph/minimalSize", 30).toInt());
 
-    ui->linesSB->setValue(mSettings->value("grid/lines", 1).toInt());
+    ui->linesSB->setValue(settings().value("grid/lines", 1).toInt());
 
-    ui->titleLE->setText(mSettings->value("title/label", QString()).toString());
+    ui->titleLE->setText(settings().value("title/label", QString()).toString());
 
-    int typeIndex = ui->typeCOB->findData(mSettings->value("data/type", msStatTypes[0]));
+    int typeIndex = ui->typeCOB->findData(settings().value("data/type", msStatTypes[0]));
     ui->typeCOB->setCurrentIndex((typeIndex >= 0) ? typeIndex : 0);
     on_typeCOB_currentIndexChanged(ui->typeCOB->currentIndex());
 
-    int sourceIndex = ui->sourceCOB->findData(mSettings->value("data/source", QString()));
+    int sourceIndex = ui->sourceCOB->findData(settings().value("data/source", QString()));
     ui->sourceCOB->setCurrentIndex((sourceIndex >= 0) ? sourceIndex : 0);
 
-    ui->useFrequencyCB->setChecked(mSettings->value("cpu/useFrequency", true).toBool());
-    ui->maximumHS->setValue(PluginSysStat::netSpeedFromString(mSettings->value("net/maximumSpeed", "1 MB/s").toString()));
+    ui->useFrequencyCB->setChecked(settings().value("cpu/useFrequency", true).toBool());
+    ui->maximumHS->setValue(PluginSysStat::netSpeedFromString(settings().value("net/maximumSpeed", "1 MB/s").toString()));
     on_maximumHS_valueChanged(ui->maximumHS->value());
-    ui->logarithmicCB->setChecked(mSettings->value("net/logarithmicScale", true).toBool());
-    ui->logScaleSB->setValue(mSettings->value("net/logarithmicScaleSteps", 4).toInt());
+    ui->logarithmicCB->setChecked(settings().value("net/logarithmicScale", true).toBool());
+    ui->logScaleSB->setValue(settings().value("net/logarithmicScaleSteps", 4).toInt());
 
-    bool useThemeColours = mSettings->value("graph/useThemeColours", true).toBool();
+    bool useThemeColours = settings().value("graph/useThemeColours", true).toBool();
     ui->useThemeColoursRB->setChecked(useThemeColours);
     ui->useCustomColoursRB->setChecked(!useThemeColours);
     ui->customColoursB->setEnabled(!useThemeColours);
@@ -147,37 +145,26 @@ void LXQtSysStatConfiguration::loadSettings()
 
 void LXQtSysStatConfiguration::saveSettings()
 {
-    mSettings->setValue("graph/useThemeColours", ui->useThemeColoursRB->isChecked());
-    mSettings->setValue("graph/updateInterval", ui->intervalSB->value());
-    mSettings->setValue("graph/minimalSize", ui->sizeSB->value());
+    settings().setValue("graph/useThemeColours", ui->useThemeColoursRB->isChecked());
+    settings().setValue("graph/updateInterval", ui->intervalSB->value());
+    settings().setValue("graph/minimalSize", ui->sizeSB->value());
 
-    mSettings->setValue("grid/lines", ui->linesSB->value());
+    settings().setValue("grid/lines", ui->linesSB->value());
 
-    mSettings->setValue("title/label", ui->titleLE->text());
+    settings().setValue("title/label", ui->titleLE->text());
 
     //Note:
     // need to make a realy deep copy of the msStatTypes[x] because of SEGFAULTs
     // occuring in static finalization time (don't know the real reason...maybe ordering of static finalizers/destructors)
     QString type = ui->typeCOB->itemData(ui->typeCOB->currentIndex(), Qt::UserRole).toString().toStdString().c_str();
-    mSettings->setValue("data/type", type);
-    mSettings->setValue("data/source", ui->sourceCOB->itemData(ui->sourceCOB->currentIndex(), Qt::UserRole));
+    settings().setValue("data/type", type);
+    settings().setValue("data/source", ui->sourceCOB->itemData(ui->sourceCOB->currentIndex(), Qt::UserRole));
 
-    mSettings->setValue("cpu/useFrequency", ui->useFrequencyCB->isChecked());
+    settings().setValue("cpu/useFrequency", ui->useFrequencyCB->isChecked());
 
-    mSettings->setValue("net/maximumSpeed", PluginSysStat::netSpeedToString(ui->maximumHS->value()));
-    mSettings->setValue("net/logarithmicScale", ui->logarithmicCB->isChecked());
-    mSettings->setValue("net/logarithmicScaleSteps", ui->logScaleSB->value());
-}
-
-void LXQtSysStatConfiguration::on_buttons_clicked(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        oldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-        close();
+    settings().setValue("net/maximumSpeed", PluginSysStat::netSpeedToString(ui->maximumHS->value()));
+    settings().setValue("net/logarithmicScale", ui->logarithmicCB->isChecked());
+    settings().setValue("net/logarithmicScaleSteps", ui->logScaleSB->value());
 }
 
 void LXQtSysStatConfiguration::on_typeCOB_currentIndexChanged(int index)
@@ -216,22 +203,22 @@ void LXQtSysStatConfiguration::coloursChanged()
 {
     const LXQtSysStatColours::Colours &colours = mColoursDialog->colours();
 
-    mSettings->setValue("grid/colour",  colours["grid"].name());
-    mSettings->setValue("title/colour", colours["title"].name());
+    settings().setValue("grid/colour",  colours["grid"].name());
+    settings().setValue("title/colour", colours["title"].name());
 
-    mSettings->setValue("cpu/systemColour",    colours["cpuSystem"].name());
-    mSettings->setValue("cpu/userColour",      colours["cpuUser"].name());
-    mSettings->setValue("cpu/niceColour",      colours["cpuNice"].name());
-    mSettings->setValue("cpu/otherColour",     colours["cpuOther"].name());
-    mSettings->setValue("cpu/frequencyColour", colours["cpuFrequency"].name());
+    settings().setValue("cpu/systemColour",    colours["cpuSystem"].name());
+    settings().setValue("cpu/userColour",      colours["cpuUser"].name());
+    settings().setValue("cpu/niceColour",      colours["cpuNice"].name());
+    settings().setValue("cpu/otherColour",     colours["cpuOther"].name());
+    settings().setValue("cpu/frequencyColour", colours["cpuFrequency"].name());
 
-    mSettings->setValue("mem/appsColour",    colours["memApps"].name());
-    mSettings->setValue("mem/buffersColour", colours["memBuffers"].name());
-    mSettings->setValue("mem/cachedColour",  colours["memCached"].name());
-    mSettings->setValue("mem/swapColour",    colours["memSwap"].name());
+    settings().setValue("mem/appsColour",    colours["memApps"].name());
+    settings().setValue("mem/buffersColour", colours["memBuffers"].name());
+    settings().setValue("mem/cachedColour",  colours["memCached"].name());
+    settings().setValue("mem/swapColour",    colours["memSwap"].name());
 
-    mSettings->setValue("net/receivedColour",    colours["netReceived"].name());
-    mSettings->setValue("net/transmittedColour", colours["netTransmitted"].name());
+    settings().setValue("net/receivedColour",    colours["netReceived"].name());
+    settings().setValue("net/transmittedColour", colours["netTransmitted"].name());
 }
 
 void LXQtSysStatConfiguration::on_customColoursB_clicked()
@@ -246,22 +233,22 @@ void LXQtSysStatConfiguration::on_customColoursB_clicked()
 
     const LXQtSysStatColours::Colours &defaultColours = mColoursDialog->defaultColours();
 
-    colours["grid"]  = QColor(mSettings->value("grid/colour",  defaultColours["grid"] .name()).toString());
-    colours["title"] = QColor(mSettings->value("title/colour", defaultColours["title"].name()).toString());
+    colours["grid"]  = QColor(settings().value("grid/colour",  defaultColours["grid"] .name()).toString());
+    colours["title"] = QColor(settings().value("title/colour", defaultColours["title"].name()).toString());
 
-    colours["cpuSystem"]    = QColor(mSettings->value("cpu/systemColour",    defaultColours["cpuSystem"]   .name()).toString());
-    colours["cpuUser"]      = QColor(mSettings->value("cpu/userColour",      defaultColours["cpuUser"]     .name()).toString());
-    colours["cpuNice"]      = QColor(mSettings->value("cpu/niceColour",      defaultColours["cpuNice"]     .name()).toString());
-    colours["cpuOther"]     = QColor(mSettings->value("cpu/otherColour",     defaultColours["cpuOther"]    .name()).toString());
-    colours["cpuFrequency"] = QColor(mSettings->value("cpu/frequencyColour", defaultColours["cpuFrequency"].name()).toString());
+    colours["cpuSystem"]    = QColor(settings().value("cpu/systemColour",    defaultColours["cpuSystem"]   .name()).toString());
+    colours["cpuUser"]      = QColor(settings().value("cpu/userColour",      defaultColours["cpuUser"]     .name()).toString());
+    colours["cpuNice"]      = QColor(settings().value("cpu/niceColour",      defaultColours["cpuNice"]     .name()).toString());
+    colours["cpuOther"]     = QColor(settings().value("cpu/otherColour",     defaultColours["cpuOther"]    .name()).toString());
+    colours["cpuFrequency"] = QColor(settings().value("cpu/frequencyColour", defaultColours["cpuFrequency"].name()).toString());
 
-    colours["memApps"]    = QColor(mSettings->value("mem/appsColour",    defaultColours["memApps"]   .name()).toString());
-    colours["memBuffers"] = QColor(mSettings->value("mem/buffersColour", defaultColours["memBuffers"].name()).toString());
-    colours["memCached"]  = QColor(mSettings->value("mem/cachedColour",  defaultColours["memCached"] .name()).toString());
-    colours["memSwap"]    = QColor(mSettings->value("mem/swapColour",    defaultColours["memSwap"]   .name()).toString());
+    colours["memApps"]    = QColor(settings().value("mem/appsColour",    defaultColours["memApps"]   .name()).toString());
+    colours["memBuffers"] = QColor(settings().value("mem/buffersColour", defaultColours["memBuffers"].name()).toString());
+    colours["memCached"]  = QColor(settings().value("mem/cachedColour",  defaultColours["memCached"] .name()).toString());
+    colours["memSwap"]    = QColor(settings().value("mem/swapColour",    defaultColours["memSwap"]   .name()).toString());
 
-    colours["netReceived"]    = QColor(mSettings->value("net/receivedColour",    defaultColours["netReceived"]   .name()).toString());
-    colours["netTransmitted"] = QColor(mSettings->value("net/transmittedColour", defaultColours["netTransmitted"].name()).toString());
+    colours["netReceived"]    = QColor(settings().value("net/receivedColour",    defaultColours["netReceived"]   .name()).toString());
+    colours["netTransmitted"] = QColor(settings().value("net/transmittedColour", defaultColours["netTransmitted"].name()).toString());
 
     mColoursDialog->setColours(colours);
 

--- a/plugin-sysstat/lxqtsysstatconfiguration.h
+++ b/plugin-sysstat/lxqtsysstatconfiguration.h
@@ -29,12 +29,10 @@
 #ifndef LXQTSYSSTATCONFIGURATION_H
 #define LXQTSYSSTATCONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 #include <QAbstractButton>
 #include <QMap>
-
 
 namespace Ui {
     class LXQtSysStatConfiguration;
@@ -46,12 +44,12 @@ namespace SysStat {
 
 class LXQtSysStatColours;
 
-class LXQtSysStatConfiguration : public QDialog
+class LXQtSysStatConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtSysStatConfiguration(QSettings *settings, QWidget *parent = 0);
+    explicit LXQtSysStatConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtSysStatConfiguration();
 
 public slots:
@@ -60,7 +58,6 @@ public slots:
     void on_typeCOB_currentIndexChanged(int);
     void on_maximumHS_valueChanged(int);
     void on_customColoursB_clicked();
-    void on_buttons_clicked(QAbstractButton *);
 
     void coloursChanged();
 
@@ -72,14 +69,10 @@ signals:
 
 private:
     Ui::LXQtSysStatConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache oldSettings;
+    SysStat::BaseStat *mStat;
+    LXQtSysStatColours *mColoursDialog;
 
     void loadSettings();
-
-    SysStat::BaseStat *mStat;
-
-    LXQtSysStatColours *mColoursDialog;
 };
 
 #endif // LXQTSYSSTATCONFIGURATION_H

--- a/plugin-taskbar/lxqttaskbarconfiguration.cpp
+++ b/plugin-taskbar/lxqttaskbarconfiguration.cpp
@@ -32,11 +32,9 @@
 #include "ui_lxqttaskbarconfiguration.h"
 #include <KWindowSystem/KWindowSystem>
 
-LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(QSettings &settings, QWidget *parent):
-    QDialog(parent),
-    ui(new Ui::LXQtTaskbarConfiguration),
-    mSettings(settings),
-    oldSettings(settings)
+LXQtTaskbarConfiguration::LXQtTaskbarConfiguration(QSettings *settings, QWidget *parent):
+    LXQtPanelPluginConfigDialog(settings, parent),
+    ui(new Ui::LXQtTaskbarConfiguration)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName("TaskbarConfigurationWindow");
@@ -80,52 +78,35 @@ LXQtTaskbarConfiguration::~LXQtTaskbarConfiguration()
 
 void LXQtTaskbarConfiguration::loadSettings()
 {
-    const bool showOnlyOneDesktopTasks = mSettings.value("showOnlyOneDesktopTasks", false).toBool();
+    const bool showOnlyOneDesktopTasks = settings().value("showOnlyOneDesktopTasks", false).toBool();
     ui->limitByDesktopCB->setChecked(showOnlyOneDesktopTasks);
-    ui->showDesktopNumCB->setCurrentIndex(ui->showDesktopNumCB->findData(mSettings.value("showDesktopNum", 0).toInt()));
+    ui->showDesktopNumCB->setCurrentIndex(ui->showDesktopNumCB->findData(settings().value("showDesktopNum", 0).toInt()));
     ui->showDesktopNumCB->setEnabled(showOnlyOneDesktopTasks);
-    ui->limitByScreenCB->setChecked(mSettings.value("showOnlyCurrentScreenTasks", false).toBool());
-    ui->limitByMinimizedCB->setChecked(mSettings.value("showOnlyMinimizedTasks", false).toBool());
+    ui->limitByScreenCB->setChecked(settings().value("showOnlyCurrentScreenTasks", false).toBool());
+    ui->limitByMinimizedCB->setChecked(settings().value("showOnlyMinimizedTasks", false).toBool());
 
-    ui->autoRotateCB->setChecked(mSettings.value("autoRotate", true).toBool());
-    ui->middleClickCB->setChecked(mSettings.value("closeOnMiddleClick", true).toBool());
-    ui->raiseOnCurrentDesktopCB->setChecked(mSettings.value("raiseOnCurrentDesktop", false).toBool());
-    ui->buttonStyleCB->setCurrentIndex(ui->buttonStyleCB->findData(mSettings.value("buttonStyle", "IconText")));
-    ui->buttonWidthSB->setValue(mSettings.value("buttonWidth", 400).toInt());
-    ui->buttonHeightSB->setValue(mSettings.value("buttonHeight", 100).toInt());
-    ui->groupingGB->setChecked(mSettings.value("groupingEnabled",true).toBool());
-    ui->showGroupOnHoverCB->setChecked(mSettings.value("showGroupOnHover",true).toBool());
+    ui->autoRotateCB->setChecked(settings().value("autoRotate", true).toBool());
+    ui->middleClickCB->setChecked(settings().value("closeOnMiddleClick", true).toBool());
+    ui->raiseOnCurrentDesktopCB->setChecked(settings().value("raiseOnCurrentDesktop", false).toBool());
+    ui->buttonStyleCB->setCurrentIndex(ui->buttonStyleCB->findData(settings().value("buttonStyle", "IconText")));
+    ui->buttonWidthSB->setValue(settings().value("buttonWidth", 400).toInt());
+    ui->buttonHeightSB->setValue(settings().value("buttonHeight", 100).toInt());
+    ui->groupingGB->setChecked(settings().value("groupingEnabled",true).toBool());
+    ui->showGroupOnHoverCB->setChecked(settings().value("showGroupOnHover",true).toBool());
 }
 
 void LXQtTaskbarConfiguration::saveSettings()
 {
-    mSettings.setValue("showOnlyOneDesktopTasks", ui->limitByDesktopCB->isChecked());
-    mSettings.setValue("showDesktopNum", ui->showDesktopNumCB->itemData(ui->showDesktopNumCB->currentIndex()));
-    mSettings.setValue("showOnlyCurrentScreenTasks", ui->limitByScreenCB->isChecked());
-    mSettings.setValue("showOnlyMinimizedTasks", ui->limitByMinimizedCB->isChecked());
-    mSettings.setValue("buttonStyle", ui->buttonStyleCB->itemData(ui->buttonStyleCB->currentIndex()));
-    mSettings.setValue("buttonWidth", ui->buttonWidthSB->value());
-    mSettings.setValue("buttonHeight", ui->buttonHeightSB->value());
-    mSettings.setValue("autoRotate", ui->autoRotateCB->isChecked());
-    mSettings.setValue("closeOnMiddleClick", ui->middleClickCB->isChecked());
-    mSettings.setValue("raiseOnCurrentDesktop", ui->raiseOnCurrentDesktopCB->isChecked());
-    mSettings.setValue("groupingEnabled",ui->groupingGB->isChecked());
-    mSettings.setValue("showGroupOnHover",ui->showGroupOnHoverCB->isChecked());
-}
-
-void LXQtTaskbarConfiguration::dialogButtonsAction(QAbstractButton *btn)
-{
-    if (ui->buttons->buttonRole(btn) == QDialogButtonBox::ResetRole)
-    {
-        /* We have to disable signals for buttonWidthSB to prevent errors. Otherwise not all data
-          could be restored */
-        ui->buttonWidthSB->blockSignals(true);
-        ui->buttonHeightSB->blockSignals(true);
-        oldSettings.loadToSettings();
-        loadSettings();
-        ui->buttonWidthSB->blockSignals(false);
-        ui->buttonHeightSB->blockSignals(false);
-    }
-    else
-        close();
+    settings().setValue("showOnlyOneDesktopTasks", ui->limitByDesktopCB->isChecked());
+    settings().setValue("showDesktopNum", ui->showDesktopNumCB->itemData(ui->showDesktopNumCB->currentIndex()));
+    settings().setValue("showOnlyCurrentScreenTasks", ui->limitByScreenCB->isChecked());
+    settings().setValue("showOnlyMinimizedTasks", ui->limitByMinimizedCB->isChecked());
+    settings().setValue("buttonStyle", ui->buttonStyleCB->itemData(ui->buttonStyleCB->currentIndex()));
+    settings().setValue("buttonWidth", ui->buttonWidthSB->value());
+    settings().setValue("buttonHeight", ui->buttonHeightSB->value());
+    settings().setValue("autoRotate", ui->autoRotateCB->isChecked());
+    settings().setValue("closeOnMiddleClick", ui->middleClickCB->isChecked());
+    settings().setValue("raiseOnCurrentDesktop", ui->raiseOnCurrentDesktopCB->isChecked());
+    settings().setValue("groupingEnabled",ui->groupingGB->isChecked());
+    settings().setValue("showGroupOnHover",ui->showGroupOnHoverCB->isChecked());
 }

--- a/plugin-taskbar/lxqttaskbarconfiguration.h
+++ b/plugin-taskbar/lxqttaskbarconfiguration.h
@@ -28,27 +28,24 @@
 #ifndef LXQTTASKBARCONFIGURATION_H
 #define LXQTTASKBARCONFIGURATION_H
 
-#include <QDialog>
-#include <QAbstractButton>
-
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
+#include <QAbstractButton>
 
 namespace Ui {
     class LXQtTaskbarConfiguration;
 }
 
-class LXQtTaskbarConfiguration : public QDialog
+class LXQtTaskbarConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtTaskbarConfiguration(QSettings &settings, QWidget *parent = 0);
+    explicit LXQtTaskbarConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtTaskbarConfiguration();
 
 private:
     Ui::LXQtTaskbarConfiguration *ui;
-    QSettings &mSettings;
-    LXQt::SettingsCache oldSettings;
 
     /*
       Read settings from conf file and put data into controls.
@@ -57,7 +54,6 @@ private:
 
 private slots:
     void saveSettings();
-    void dialogButtonsAction(QAbstractButton *btn);
 };
 
 #endif // LXQTTASKBARCONFIGURATION_H

--- a/plugin-taskbar/lxqttaskbarplugin.cpp
+++ b/plugin-taskbar/lxqttaskbarplugin.cpp
@@ -45,7 +45,7 @@ LXQtTaskBarPlugin::~LXQtTaskBarPlugin()
 
 QDialog *LXQtTaskBarPlugin::configureDialog()
 {
-    return new LXQtTaskbarConfiguration(*(settings()));
+    return new LXQtTaskbarConfiguration(settings());
 }
 
 void LXQtTaskBarPlugin::realign()

--- a/plugin-volume/lxqtvolume.cpp
+++ b/plugin-volume/lxqtvolume.cpp
@@ -254,14 +254,14 @@ void LXQtVolume::realign()
 
 QDialog *LXQtVolume::configureDialog()
 {
-	if(!m_configDialog)
-	{
-		m_configDialog = new LXQtVolumeConfiguration(*settings());
-		m_configDialog->setAttribute(Qt::WA_DeleteOnClose, true);
+    if (!m_configDialog)
+    {
+        m_configDialog = new LXQtVolumeConfiguration(settings());
+        m_configDialog->setAttribute(Qt::WA_DeleteOnClose, true);
 
-		if (m_engine)
-		   m_configDialog->setSinkList(m_engine->sinks());
-	}
+        if (m_engine)
+           m_configDialog->setSinkList(m_engine->sinks());
+    }
     return m_configDialog;
 }
 

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -33,7 +33,7 @@
 #include <QComboBox>
 #include <QDebug>
 
-LXQtVolumeConfiguration::LXQtVolumeConfiguration(QSettings &settings, QWidget *parent) :
+LXQtVolumeConfiguration::LXQtVolumeConfiguration(QSettings *settings, QWidget *parent) :
     LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtVolumeConfiguration)
 {

--- a/plugin-volume/lxqtvolumeconfiguration.h
+++ b/plugin-volume/lxqtvolumeconfiguration.h
@@ -67,7 +67,7 @@ class LXQtVolumeConfiguration : public LXQtPanelPluginConfigDialog
     Q_OBJECT
 
 public:
-    explicit LXQtVolumeConfiguration(QSettings &settings, QWidget *parent = 0);
+    explicit LXQtVolumeConfiguration(QSettings *settings, QWidget *parent = 0);
     ~LXQtVolumeConfiguration();
 
 public slots:

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -38,13 +38,11 @@
 
 
 LXQtWorldClockConfiguration::LXQtWorldClockConfiguration(QSettings *settings, QWidget *parent) :
-    QDialog(parent),
+    LXQtPanelPluginConfigDialog(settings, parent),
     ui(new Ui::LXQtWorldClockConfiguration),
-    mSettings(settings),
-    mOldSettings(settings),
     mLockCascadeSettingChanges(false),
-    mConfigurationTimeZones(NULL),
-    mConfigurationManualFormat(NULL)
+    mConfigurationTimeZones(nullptr),
+    mConfigurationManualFormat(nullptr)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setObjectName(QLatin1String("WorldClockConfigurationWindow"));
@@ -99,10 +97,10 @@ void LXQtWorldClockConfiguration::loadSettings()
 
     bool longTimeFormatSelected = false;
 
-    QString formatType = mSettings->value(QLatin1String("formatType"), QString()).toString();
-    QString dateFormatType = mSettings->value(QLatin1String("dateFormatType"), QString()).toString();
-    bool advancedManual = mSettings->value(QLatin1String("useAdvancedManualFormat"), false).toBool();
-    mManualFormat = mSettings->value(QLatin1String("customFormat"), tr("'<b>'HH:mm:ss'</b><br/><font size=\"-2\">'ddd, d MMM yyyy'<br/>'TT'</font>'")).toString();
+    QString formatType = settings().value(QLatin1String("formatType"), QString()).toString();
+    QString dateFormatType = settings().value(QLatin1String("dateFormatType"), QString()).toString();
+    bool advancedManual = settings().value(QLatin1String("useAdvancedManualFormat"), false).toBool();
+    mManualFormat = settings().value(QLatin1String("customFormat"), tr("'<b>'HH:mm:ss'</b><br/><font size=\"-2\">'ddd, d MMM yyyy'<br/>'TT'</font>'")).toString();
 
     // backward compatibility
     if (formatType == QLatin1String("custom"))
@@ -137,9 +135,9 @@ void LXQtWorldClockConfiguration::loadSettings()
     else // if (formatType == QLatin1String("custom-timeonly"))
         ui->timeFormatCB->setCurrentIndex(2);
 
-    ui->timeShowSecondsCB->setChecked(mSettings->value(QLatin1String("timeShowSeconds"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
-    ui->timePadHourCB->setChecked(mSettings->value(QLatin1String("timePadHour"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
-    ui->timeAMPMCB->setChecked(mSettings->value(QLatin1String("timeAMPM"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->timeShowSecondsCB->setChecked(settings().value(QLatin1String("timeShowSeconds"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->timePadHourCB->setChecked(settings().value(QLatin1String("timePadHour"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->timeAMPMCB->setChecked(settings().value(QLatin1String("timeAMPM"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
 
     bool customTimeFormatSelected = ui->timeFormatCB->currentIndex() == ui->timeFormatCB->count() - 1;
     ui->timeCustomW->setEnabled(customTimeFormatSelected);
@@ -147,9 +145,9 @@ void LXQtWorldClockConfiguration::loadSettings()
     ui->timezoneGB->setEnabled(!longTimeFormatSelected);
 
     // timezone
-    ui->timezoneGB->setChecked(mSettings->value(QLatin1String("showTimezone"), false).toBool() && !longTimeFormatSelected);
+    ui->timezoneGB->setChecked(settings().value(QLatin1String("showTimezone"), false).toBool() && !longTimeFormatSelected);
 
-    QString timezonePosition = mSettings->value(QLatin1String("timezonePosition"), QString()).toString();
+    QString timezonePosition = settings().value(QLatin1String("timezonePosition"), QString()).toString();
     if (timezonePosition == QLatin1String("above"))
         ui->timezonePositionCB->setCurrentIndex(1);
     else if (timezonePosition == QLatin1String("before"))
@@ -159,7 +157,7 @@ void LXQtWorldClockConfiguration::loadSettings()
     else // if (timezonePosition == QLatin1String("below"))
         ui->timezonePositionCB->setCurrentIndex(0);
 
-    QString timezoneFormatType = mSettings->value(QLatin1String("timezoneFormatType"), QString()).toString();
+    QString timezoneFormatType = settings().value(QLatin1String("timezoneFormatType"), QString()).toString();
     if (timezoneFormatType == QLatin1String("short"))
         ui->timezoneFormatCB->setCurrentIndex(0);
     else if (timezoneFormatType == QLatin1String("long"))
@@ -172,10 +170,10 @@ void LXQtWorldClockConfiguration::loadSettings()
         ui->timezoneFormatCB->setCurrentIndex(4);
 
     // date
-    bool dateIsChecked = mSettings->value(QLatin1String("showDate"), false).toBool();
+    bool dateIsChecked = settings().value(QLatin1String("showDate"), false).toBool();
     ui->dateGB->setChecked(dateIsChecked);
 
-    QString datePosition = mSettings->value(QLatin1String("datePosition"), QString()).toString();
+    QString datePosition = settings().value(QLatin1String("datePosition"), QString()).toString();
     if (datePosition == QLatin1String("above"))
         ui->datePositionCB->setCurrentIndex(1);
     else if (datePosition == QLatin1String("before"))
@@ -194,10 +192,10 @@ void LXQtWorldClockConfiguration::loadSettings()
     else // if (dateFormatType == QLatin1String("custom"))
         ui->dateFormatCB->setCurrentIndex(3);
 
-    ui->dateShowYearCB->setChecked(mSettings->value(QLatin1String("dateShowYear"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
-    ui->dateShowDoWCB->setChecked(mSettings->value(QLatin1String("dateShowDoW"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
-    ui->datePadDayCB->setChecked(mSettings->value(QLatin1String("datePadDay"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
-    ui->dateLongNamesCB->setChecked(mSettings->value(QLatin1String("dateLongNames"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->dateShowYearCB->setChecked(settings().value(QLatin1String("dateShowYear"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->dateShowDoWCB->setChecked(settings().value(QLatin1String("dateShowDoW"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->datePadDayCB->setChecked(settings().value(QLatin1String("datePadDay"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
+    ui->dateLongNamesCB->setChecked(settings().value(QLatin1String("dateLongNames"), false).toBool() ? Qt::Checked : Qt:: Unchecked);
 
     bool customDateFormatSelected = ui->dateFormatCB->currentIndex() == ui->dateFormatCB->count() - 1;
     ui->dateCustomW->setEnabled(dateIsChecked && customDateFormatSelected);
@@ -206,31 +204,31 @@ void LXQtWorldClockConfiguration::loadSettings()
     ui->advancedManualGB->setChecked(advancedManual);
 
 
-    mDefaultTimeZone = mSettings->value("defaultTimeZone", QString()).toString();
+    mDefaultTimeZone = settings().value("defaultTimeZone", QString()).toString();
 
     ui->timeZonesTW->setRowCount(0);
 
-    int size = mSettings->beginReadArray(QLatin1String("timeZones"));
+    int size = settings().beginReadArray(QLatin1String("timeZones"));
     for (int i = 0; i < size; ++i)
     {
-        mSettings->setArrayIndex(i);
+        settings().setArrayIndex(i);
         ui->timeZonesTW->setRowCount(ui->timeZonesTW->rowCount() + 1);
 
-        QString timeZoneName = mSettings->value(QLatin1String("timeZone"), QString()).toString();
+        QString timeZoneName = settings().value(QLatin1String("timeZone"), QString()).toString();
         if (mDefaultTimeZone.isEmpty())
             mDefaultTimeZone = timeZoneName;
 
         ui->timeZonesTW->setItem(i, 0, new QTableWidgetItem(timeZoneName));
-        ui->timeZonesTW->setItem(i, 1, new QTableWidgetItem(mSettings->value(QLatin1String("customName"), QString()).toString()));
+        ui->timeZonesTW->setItem(i, 1, new QTableWidgetItem(settings().value(QLatin1String("customName"), QString()).toString()));
 
         setBold(i, mDefaultTimeZone == timeZoneName);
     }
-    mSettings->endArray();
+    settings().endArray();
 
     ui->timeZonesTW->resizeColumnsToContents();
 
 
-    ui->autorotateCB->setChecked(mSettings->value("autoRotate", true).toBool());
+    ui->autorotateCB->setChecked(settings().value("autoRotate", true).toBool());
 
 
     mLockCascadeSettingChanges = false;
@@ -256,13 +254,13 @@ void LXQtWorldClockConfiguration::saveSettings()
         formatType = QLatin1String("custom-timeonly");
         break;
     }
-    mSettings->setValue(QLatin1String("formatType"), formatType);
+    settings().setValue(QLatin1String("formatType"), formatType);
 
-    mSettings->setValue(QLatin1String("timeShowSeconds"), ui->timeShowSecondsCB->isChecked());
-    mSettings->setValue(QLatin1String("timePadHour"), ui->timePadHourCB->isChecked());
-    mSettings->setValue(QLatin1String("timeAMPM"), ui->timeAMPMCB->isChecked());
+    settings().setValue(QLatin1String("timeShowSeconds"), ui->timeShowSecondsCB->isChecked());
+    settings().setValue(QLatin1String("timePadHour"), ui->timePadHourCB->isChecked());
+    settings().setValue(QLatin1String("timeAMPM"), ui->timeAMPMCB->isChecked());
 
-    mSettings->setValue(QLatin1String("showTimezone"), ui->timezoneGB->isChecked());
+    settings().setValue(QLatin1String("showTimezone"), ui->timezoneGB->isChecked());
 
     QString timezonePosition;
     switch (ui->timezonePositionCB->currentIndex())
@@ -283,7 +281,7 @@ void LXQtWorldClockConfiguration::saveSettings()
         timezonePosition = QLatin1String("after");
         break;
     }
-    mSettings->setValue(QLatin1String("timezonePosition"), timezonePosition);
+    settings().setValue(QLatin1String("timezonePosition"), timezonePosition);
 
     QString timezoneFormatType;
     switch (ui->timezoneFormatCB->currentIndex())
@@ -308,9 +306,9 @@ void LXQtWorldClockConfiguration::saveSettings()
         timezoneFormatType = QLatin1String("iana");
         break;
     }
-    mSettings->setValue(QLatin1String("timezoneFormatType"), timezoneFormatType);
+    settings().setValue(QLatin1String("timezoneFormatType"), timezoneFormatType);
 
-    mSettings->setValue(QLatin1String("showDate"), ui->dateGB->isChecked());
+    settings().setValue(QLatin1String("showDate"), ui->dateGB->isChecked());
 
     QString datePosition;
     switch (ui->datePositionCB->currentIndex())
@@ -331,7 +329,7 @@ void LXQtWorldClockConfiguration::saveSettings()
         datePosition = QLatin1String("after");
         break;
     }
-    mSettings->setValue(QLatin1String("datePosition"), datePosition);
+    settings().setValue(QLatin1String("datePosition"), datePosition);
 
     QString dateFormatType;
     switch (ui->dateFormatCB->currentIndex())
@@ -352,46 +350,35 @@ void LXQtWorldClockConfiguration::saveSettings()
         dateFormatType = QLatin1String("custom");
         break;
     }
-    mSettings->setValue(QLatin1String("dateFormatType"), dateFormatType);
+    settings().setValue(QLatin1String("dateFormatType"), dateFormatType);
 
-    mSettings->setValue(QLatin1String("dateShowYear"), ui->dateShowYearCB->isChecked());
-    mSettings->setValue(QLatin1String("dateShowDoW"), ui->dateShowDoWCB->isChecked());
-    mSettings->setValue(QLatin1String("datePadDay"), ui->datePadDayCB->isChecked());
-    mSettings->setValue(QLatin1String("dateLongNames"), ui->dateLongNamesCB->isChecked());
+    settings().setValue(QLatin1String("dateShowYear"), ui->dateShowYearCB->isChecked());
+    settings().setValue(QLatin1String("dateShowDoW"), ui->dateShowDoWCB->isChecked());
+    settings().setValue(QLatin1String("datePadDay"), ui->datePadDayCB->isChecked());
+    settings().setValue(QLatin1String("dateLongNames"), ui->dateLongNamesCB->isChecked());
 
-    mSettings->setValue(QLatin1String("customFormat"), mManualFormat);
+    settings().setValue(QLatin1String("customFormat"), mManualFormat);
 
 
-    mSettings->remove(QLatin1String("timeZones"));
+    settings().remove(QLatin1String("timeZones"));
 
     int size = ui->timeZonesTW->rowCount();
-    mSettings->beginWriteArray(QLatin1String("timeZones"), size);
+    settings().beginWriteArray(QLatin1String("timeZones"), size);
     for (int i = 0; i < size; ++i)
     {
-        mSettings->setArrayIndex(i);
-        mSettings->setValue(QLatin1String("timeZone"), ui->timeZonesTW->item(i, 0)->text());
-        mSettings->setValue(QLatin1String("customName"), ui->timeZonesTW->item(i, 1)->text());
+        settings().setArrayIndex(i);
+        settings().setValue(QLatin1String("timeZone"), ui->timeZonesTW->item(i, 0)->text());
+        settings().setValue(QLatin1String("customName"), ui->timeZonesTW->item(i, 1)->text());
     }
-    mSettings->endArray();
+    settings().endArray();
 
-    mSettings->setValue(QLatin1String("defaultTimeZone"), mDefaultTimeZone);
-
-
-    mSettings->setValue(QLatin1String("useAdvancedManualFormat"), ui->advancedManualGB->isChecked());
+    settings().setValue(QLatin1String("defaultTimeZone"), mDefaultTimeZone);
 
 
-    mSettings->setValue(QLatin1String("autoRotate"), ui->autorotateCB->isChecked());
-}
+    settings().setValue(QLatin1String("useAdvancedManualFormat"), ui->advancedManualGB->isChecked());
 
-void LXQtWorldClockConfiguration::dialogButtonsAction(QAbstractButton *button)
-{
-    if (ui->buttons->buttonRole(button) == QDialogButtonBox::ResetRole)
-    {
-        mOldSettings.loadToSettings();
-        loadSettings();
-    }
-    else
-        close();
+
+    settings().setValue(QLatin1String("autoRotate"), ui->autorotateCB->isChecked());
 }
 
 void LXQtWorldClockConfiguration::timeFormatChanged(int index)

--- a/plugin-worldclock/lxqtworldclockconfiguration.h
+++ b/plugin-worldclock/lxqtworldclockconfiguration.h
@@ -29,13 +29,11 @@
 #ifndef LXQT_PANEL_WORLDCLOCK_CONFIGURATION_H
 #define LXQT_PANEL_WORLDCLOCK_CONFIGURATION_H
 
+#include "../panel/lxqtpanelpluginconfigdialog.h"
 #include <LXQt/Settings>
-
-#include <QDialog>
 #include <QAbstractButton>
 #include <QFont>
 #include <QMap>
-
 
 namespace Ui {
     class LXQtWorldClockConfiguration;
@@ -45,12 +43,12 @@ class LXQtWorldClockConfigurationTimeZones;
 class LXQtWorldClockConfigurationManualFormat;
 class QTableWidgetItem;
 
-class LXQtWorldClockConfiguration : public QDialog
+class LXQtWorldClockConfiguration : public LXQtPanelPluginConfigDialog
 {
     Q_OBJECT
 
 public:
-    explicit LXQtWorldClockConfiguration(QSettings *settings, QWidget *parent = NULL);
+    explicit LXQtWorldClockConfiguration(QSettings *settings, QWidget *parent = nullptr);
     ~LXQtWorldClockConfiguration();
 
 public slots:
@@ -58,8 +56,6 @@ public slots:
 
 private:
     Ui::LXQtWorldClockConfiguration *ui;
-    QSettings *mSettings;
-    LXQt::SettingsCache mOldSettings;
 
     /*
       Read settings from conf file and put data into controls.
@@ -67,11 +63,6 @@ private:
     void loadSettings();
 
 private slots:
-    /*
-      Saves settings in conf file.
-    */
-    void dialogButtonsAction(QAbstractButton *);
-
     void timeFormatChanged(int);
     void dateGroupToggled(bool);
     void dateFormatChanged(int);


### PR DESCRIPTION
I've tested it, but it deserves more, for all plugins. Specially the reset button.