### PR TITLE
plugin settings: Publish PluginSettings symbols

### DIFF
--- a/panel/pluginsettings.h
+++ b/panel/pluginsettings.h
@@ -31,8 +31,9 @@
 #include <QObject>
 #include <QString>
 #include <LXQt/Settings>
+#include "lxqtpanelglobals.h"
 
-class PluginSettings : public QObject
+class LXQT_PANEL_API PluginSettings : public QObject
 {
     Q_OBJECT
 


### PR DESCRIPTION
On some configuration the PluginSettings symbols aren't in dynsym section.
closes lxde/lxqt#928