### PR TITLE
taskbar: Refactor/improove window handling logic

### DIFF
--- a/plugin-taskbar/lxqttaskbar.h
+++ b/plugin-taskbar/lxqttaskbar.h
@@ -41,7 +41,7 @@
 
 #include <QFrame>
 #include <QBoxLayout>
-#include <QHash>
+#include <QMap>
 #include "../panel/ilxqtpanel.h"
 #include <KWindowSystem/KWindowSystem>
 #include <KWindowSystem/KWindowInfo>
@@ -81,29 +81,34 @@ public slots:
     void settingsChanged();
 
 signals:
-    void windowRemoved(WId window);
+    void buttonRotationRefreshed(bool autoRotate, ILXQtPanel::Position position);
+    void buttonStyleRefreshed(Qt::ToolButtonStyle buttonStyle);
+    void refreshIconGeometry();
+    void showOnlySettingChanged();
+    void popupShown(LXQtTaskGroup* sender);
 
 protected:
     virtual void dragEnterEvent(QDragEnterEvent * event);
     virtual void dragMoveEvent(QDragMoveEvent * event);
 
 private slots:
-    void refreshIconGeometry();
     void refreshTaskList();
     void refreshButtonRotation();
     void refreshPlaceholderVisibility();
     void groupBecomeEmptySlot();
-    void groupPopupShown(LXQtTaskGroup * const sender);
     void onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2);
     void onWindowRemoved(WId window);
 
 private:
-    void addWindow(WId window, QString const & groupId);
+    typedef QMap<WId, LXQtTaskGroup*> windowMap_t;
+
+private:
+    void addWindow(WId window);
+    windowMap_t::iterator removeWindow(windowMap_t::iterator pos);
     void buttonMove(LXQtTaskGroup * dst, LXQtTaskGroup * src, QPoint const & pos);
 
 private:
-    QHash<QString, LXQtTaskGroup*> mGroupsHash;
-    QList<WId> mKnownWindows; //!< Ids of known windows (for emulating windowRemoved in case WId of app changes)
+    QMap<WId, LXQtTaskGroup*> mKnownWindows; //!< Ids of known windows (mapping to buttons/groups)
     LXQt::GridLayout *mLayout;
 
     // Settings

--- a/plugin-taskbar/lxqttaskgroup.h
+++ b/plugin-taskbar/lxqttaskgroup.h
@@ -54,7 +54,6 @@ public:
 
     QString groupName() const { return mGroupName; }
 
-    void removeButton(WId window);
     int buttonsCount() const;
     int visibleButtonsCount() const;
 
@@ -66,12 +65,13 @@ public:
     LXQtTaskButton * getNextPrevChildButton(bool next, bool circular);
 
     bool onWindowChanged(WId window, NET::Properties prop, NET::Properties2 prop2);
-    void refreshIconsGeometry();
-    void showOnlySettingChanged();
     void setAutoRotation(bool value, ILXQtPanel::Position position);
     void setToolButtonsStyle(Qt::ToolButtonStyle style);
 
     void setPopupVisible(bool visible = true, bool fast = false);
+
+public slots:
+    void onWindowRemoved(WId window);
 
 protected:
     QMimeData * mimeData();
@@ -91,16 +91,17 @@ private slots:
     void onClicked(bool checked);
     void onChildButtonClicked();
     void onActiveWindowChanged(WId window);
-    void onWindowRemoved(WId window);
     void onDesktopChanged(int number);
 
     void closeGroup();
+    void refreshIconsGeometry();
+    void refreshVisibility();
+    void groupPopupShown(LXQtTaskGroup* sender);
 
 signals:
     void groupBecomeEmpty(QString name);
     void visibilityChanged(bool visible);
     void popupShown(LXQtTaskGroup* sender);
-    void windowDisowned(WId window);
 
 private:
     QString mGroupName;
@@ -112,7 +113,6 @@ private:
     QSize recalculateFrameSize();
     QPoint recalculateFramePosition();
     void recalculateFrameIfVisible();
-    void refreshVisibility();
     void regroup();
 };
 


### PR DESCRIPTION
Logic changed to use just one hash Wid -> LXQtTaskGroup* to directly address "button" upon window props change.