### PR TITLE
taskbar: grouped windows should always show text

### DIFF
--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -107,7 +107,7 @@ LXQtTaskButton * LXQtTaskGroup::addWindow(WId id)
         return mButtonHash.value(id);
 
     LXQtTaskButton *btn = new LXQtTaskButton(id, parentTaskBar(), mPopup);
-    btn->setToolButtonStyle(toolButtonStyle());
+    btn->setToolButtonStyle(Qt::ToolButtonTextBesideIcon); // Grouped windows should always show text
 
     if (btn->isApplicationActive())
     {


### PR DESCRIPTION
When using an icon only taskbar, grouped windows should show text nevertheless. It looks odd to get a long bar with just one icon in the middle.