### PR TITLE
mainmenu: Fix freeze for some widget styles (e.g. breeze)

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -81,7 +81,7 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
 
     connect(&mButton, &QToolButton::clicked, this, &LXQtMainMenu::showHideMenu);
 
-    settingsChanged();
+    QTimer::singleShot(0, [this] { settingsChanged(); });
 
     mShortcut = GlobalKeyShortcut::Client::instance()->addAction(QString{}, QString("/panel/%1/show_hide").arg(settings()->group()), tr("Show/hide main menu"), this);
     if (mShortcut)
@@ -279,7 +279,6 @@ void LXQtMainMenu::setButtonIcon()
     } else
     {
         mButton.setIcon(QIcon{});
-        mButton.style()->unpolish(&mButton);
         mButton.style()->polish(&mButton);
     }
 }


### PR DESCRIPTION
According to my debuging session...the "freeze" hapens on `(un)polish()` of mainmenu button.

I'm not completely sure why this happens, but removing the `unpolish()` fixes this on my side (and does not harm applying the icon from the theme).

closes lxde/lxqt#955