### PR TITLE
mainmenu: Use "cleaner" style logic

### DIFF
--- a/plugin-spacer/spacer.cpp
+++ b/plugin-spacer/spacer.cpp
@@ -33,8 +33,7 @@ void SpacerWidget::setType(QString const & type)
     if (type != mType)
     {
         mType = type;
-        style()->unpolish(this);
-        style()->polish(this);
+        setStyle(style());
     }
 }
 
@@ -43,8 +42,7 @@ void SpacerWidget::setOrientation(QString const & orientation)
     if (orientation != mOrientation)
     {
         mOrientation = orientation;
-        style()->unpolish(this);
-        style()->polish(this);
+        setStyle(style());
     }
 }
 


### PR DESCRIPTION
Avoiding of QStyle::polish() usage... let the Qt handle it.

@tsujan Thanks for suggestions in #302.  While testing & trying different possibilities I finaly came to this one.

How do you see this? Is it "cleaner/better" ?