### PR TITLE
panellayout: Avoid plugin margins

### DIFF
--- a/panel/lxqtpanellayout.cpp
+++ b/panel/lxqtpanellayout.cpp
@@ -644,9 +644,10 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
 
     // Calc baselines for plugins like button.
     QVector<int> baseLines(qMax(mLeftGrid->colCount(), mRightGrid->colCount()));
+    const int bh = geometry.height() / baseLines.count();
+    const int base_center = bh >> 1;
     {
-        int bh = geometry.height() / baseLines.count();
-        int base = geometry.top() + (bh >> 1);
+        int base = geometry.top();
         for (auto i = baseLines.begin(), i_e = baseLines.end(); i_e != i; ++i, base += bh)
         {
             *i = base;
@@ -691,9 +692,13 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    rect.setHeight(qMin(info.geometry.height(), geometry.height()));
+                    const int height = qMin(info.geometry.height(), geometry.height());
+                    rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
-                    rect.moveCenter(QPoint(0, baseLines[c]));
+                    if (height < bh)
+                        rect.moveCenter(QPoint(0, baseLines[c] + base_center));
+                    else
+                        rect.moveTop(baseLines[c]);
                     rect.moveLeft(left);
                 }
 
@@ -729,9 +734,13 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    rect.setHeight(qMin(info.geometry.height(), geometry.height()));
+                    const int height = qMin(info.geometry.height(), geometry.height());
+                    rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
-                    rect.moveCenter(QPoint(0, baseLines[c]));
+                    if (height < bh)
+                        rect.moveCenter(QPoint(0, baseLines[c] + base_center));
+                    else
+                        rect.moveTop(baseLines[c]);
                     rect.moveRight(right);
                 }
 
@@ -760,9 +769,10 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
 
     // Calc baselines for plugins like button.
     QVector<int> baseLines(qMax(mLeftGrid->colCount(), mRightGrid->colCount()));
+    const int bw = geometry.width() / baseLines.count();
+    const int base_center = bw >> 1;
     {
-        int bw = geometry.width() / baseLines.count();
-        int base = geometry.left() + (bw >> 1);
+        int base = geometry.left();
         for (auto i = baseLines.begin(), i_e = baseLines.end(); i_e != i; ++i, base += bw)
         {
             *i = base;
@@ -807,8 +817,12 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    rect.setWidth(qMin(info.geometry.width(), geometry.width()));
-                    rect.moveCenter(QPoint(baseLines[c], 0));
+                    const int width = qMin(info.geometry.width(), geometry.width());
+                    rect.setWidth(width);
+                    if (width < bw)
+                        rect.moveCenter(QPoint(baseLines[c] + base_center, 0));
+                    else
+                        rect.moveLeft(baseLines[c]);
                     rect.moveTop(top);
                 }
 
@@ -845,8 +859,12 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    rect.setWidth(qMin(info.geometry.width(), geometry.width()));
-                    rect.moveCenter(QPoint(baseLines[c], 0));
+                    const int width = qMin(info.geometry.width(), geometry.width());
+                    rect.setWidth(width);
+                    if (width < bw)
+                        rect.moveCenter(QPoint(baseLines[c] + base_center, 0));
+                    else
+                        rect.moveLeft(baseLines[c]);
                     rect.moveBottom(bottom);
                 }
 

--- a/panel/lxqtpanellayout.cpp
+++ b/panel/lxqtpanellayout.cpp
@@ -646,6 +646,7 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
     QVector<int> baseLines(qMax(mLeftGrid->colCount(), mRightGrid->colCount()));
     const int bh = geometry.height() / baseLines.count();
     const int base_center = bh >> 1;
+    const int height_remain = 0 < bh ? geometry.height() % baseLines.size() : 0;
     {
         int base = geometry.top();
         for (auto i = baseLines.begin(), i_e = baseLines.end(); i_e != i; ++i, base += bh)
@@ -673,6 +674,7 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
     for (int r=0; r<mLeftGrid->rowCount(); ++r)
     {
         int rw = 0;
+        int remain = height_remain;
         for (int c=0; c<mLeftGrid->usedColCount(); ++c)
         {
             const LayoutItemInfo &info = mLeftGrid->itemInfo(r, c);
@@ -692,7 +694,7 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    const int height = qMin(info.geometry.height(), geometry.height());
+                    const int height = qMin(qMin(info.geometry.height(), geometry.height()), bh + (0 < remain-- ? 1 : 0));
                     rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
                     if (height < bh)
@@ -714,6 +716,7 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
     for (int r=mRightGrid->rowCount()-1; r>=0; --r)
     {
         int rw = 0;
+        int remain = height_remain;
         for (int c=0; c<mRightGrid->usedColCount(); ++c)
         {
             const LayoutItemInfo &info = mRightGrid->itemInfo(r, c);
@@ -734,7 +737,7 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    const int height = qMin(info.geometry.height(), geometry.height());
+                    const int height = qMin(qMin(info.geometry.height(), geometry.height()), bh + (0 < remain-- ? 1 : 0));
                     rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
                     if (height < bh)
@@ -771,6 +774,7 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
     QVector<int> baseLines(qMax(mLeftGrid->colCount(), mRightGrid->colCount()));
     const int bw = geometry.width() / baseLines.count();
     const int base_center = bw >> 1;
+    const int width_remain = 0 < bw ? geometry.width() % baseLines.size() : 0;
     {
         int base = geometry.left();
         for (auto i = baseLines.begin(), i_e = baseLines.end(); i_e != i; ++i, base += bw)
@@ -797,6 +801,7 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
     for (int r=0; r<mLeftGrid->rowCount(); ++r)
     {
         int rh = 0;
+        int remain = width_remain;
         for (int c=0; c<mLeftGrid->usedColCount(); ++c)
         {
             const LayoutItemInfo &info = mLeftGrid->itemInfo(r, c);
@@ -817,7 +822,7 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    const int width = qMin(info.geometry.width(), geometry.width());
+                    const int width = qMin(qMin(info.geometry.width(), geometry.width()), bw + (0 < remain-- ? 1 : 0));
                     rect.setWidth(width);
                     if (width < bw)
                         rect.moveCenter(QPoint(baseLines[c] + base_center, 0));
@@ -839,6 +844,7 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
     for (int r=mRightGrid->rowCount()-1; r>=0; --r)
     {
         int rh = 0;
+        int remain = width_remain;
         for (int c=0; c<mRightGrid->usedColCount(); ++c)
         {
             const LayoutItemInfo &info = mRightGrid->itemInfo(r, c);
@@ -859,7 +865,7 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    const int width = qMin(info.geometry.width(), geometry.width());
+                    const int width = qMin(qMin(info.geometry.width(), geometry.width()), bw + (0 < remain-- ? 1 : 0));
                     rect.setWidth(width);
                     if (width < bw)
                         rect.moveCenter(QPoint(baseLines[c] + base_center, 0));


### PR DESCRIPTION
Moving the center of computed rectagnle can lead to unused portions of
space. This was the case for standard (separate) plugins if the iconsize
was big enough to fulfill the space.

see lxde/lxqt#962