### PR TITLE
plugins: Make buttons flat for cleaner look

### DIFF
--- a/plugin-colorpicker/colorpicker.cpp
+++ b/plugin-colorpicker/colorpicker.cpp
@@ -64,6 +64,7 @@ ColorPickerWidget::ColorPickerWidget(QWidget *parent):
     layout->addWidget (&mLineEdit);
 
 
+    mButton.setAutoRaise(true);
     mButton.setIcon(XdgIcon::fromTheme("color-picker", "kcolorchooser"));
 
     mCapturing = false;

--- a/plugin-desktopswitch/desktopswitch.cpp
+++ b/plugin-desktopswitch/desktopswitch.cpp
@@ -26,7 +26,6 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include <QButtonGroup>
-#include <QToolButton>
 #include <QWheelEvent>
 #include <QtDebug>
 #include <QSignalMapper>

--- a/plugin-dom/domplugin.cpp
+++ b/plugin-dom/domplugin.cpp
@@ -35,6 +35,7 @@ DomPlugin::DomPlugin(const ILXQtPanelPluginStartupInfo &startupInfo):
     QObject(),
     ILXQtPanelPlugin(startupInfo)
 {
+    mButton.setAutoRaise(true);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     mButton.setIcon(XdgIcon::fromTheme("preferences-plugin"));
     connect(&mButton, SIGNAL(clicked()), this, SLOT(showDialog()));

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -67,6 +67,7 @@ LXQtMainMenu::LXQtMainMenu(const ILXQtPanelPluginStartupInfo &startupInfo):
     mHideTimer.setSingleShot(true);
     mHideTimer.setInterval(250);
 
+    mButton.setAutoRaise(true);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
     //Notes:
     //1. installing event filter to parent widget to avoid infinite loop

--- a/plugin-mount/button.cpp
+++ b/plugin-mount/button.cpp
@@ -37,6 +37,7 @@ Button::Button(QWidget * parent) :
     setIcon(XdgIcon::fromTheme(QLatin1String("drive-removable-media")));
     setToolTip(tr("Removable media/devices manager"));
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setAutoRaise(true);
 }
 
 Button::~Button()

--- a/plugin-quicklaunch/quicklaunchbutton.cpp
+++ b/plugin-quicklaunch/quicklaunchbutton.cpp
@@ -47,6 +47,7 @@ QuickLaunchButton::QuickLaunchButton(QuickLaunchAction * act, ILXQtPanelPlugin *
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAcceptDrops(true);
+    setAutoRaise(true);
 
     setDefaultAction(mAct);
     mAct->setParent(this);

--- a/plugin-screensaver/panelscreensaver.cpp
+++ b/plugin-screensaver/panelscreensaver.cpp
@@ -25,7 +25,6 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <QToolButton>
 #include <QMessageBox>
 #include <QHBoxLayout>
 #include <LXQt/ScreenSaver>
@@ -42,6 +41,7 @@ PanelScreenSaver::PanelScreenSaver(const ILXQtPanelPluginStartupInfo &startupInf
     QObject(),
     ILXQtPanelPlugin(startupInfo)
 {
+    mButton.setAutoRaise(true);
     mSaver = new LXQt::ScreenSaver(this);
 
     QList<QAction*> actions = mSaver->availableActions();

--- a/plugin-showdesktop/showdesktop.cpp
+++ b/plugin-showdesktop/showdesktop.cpp
@@ -25,7 +25,6 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#include <QToolButton>
 #include <QAction>
 #include <QX11Info>
 #include <lxqt-globalkeys.h>
@@ -58,6 +57,7 @@ ShowDesktop::ShowDesktop(const ILXQtPanelPluginStartupInfo &startupInfo) :
 
     mButton.setDefaultAction(act);
     mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    mButton.setAutoRaise(true);
 }
 
 void ShowDesktop::shortcutRegistered()

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -42,6 +42,7 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     mFallbackIcon(QIcon::fromTheme("application-x-executable")),
     mPlugin(plugin)
 {
+    setAutoRaise(true);
     interface = new SniAsync(service, objectPath, QDBusConnection::sessionBus(), this);
 
     connect(interface, &SniAsync::NewIcon, this, &StatusNotifierButton::newIcon);

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -45,6 +45,7 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         m_showOnClick(true),
         m_muteOnMiddleClick(true)
 {
+    setAutoRaise(true);
     // initial icon for button. It will be replaced after devices scan.
     // In the worst case - no soundcard/pulse - is found it remains
     // in the button but at least the button is not blank ("invisible")


### PR DESCRIPTION
In "system" theme the plugins were not borderless as in all "specific" themes.