### PR TITLE
plugins: Don't unload -> avoid dangling resources

### DIFF
--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -165,11 +165,7 @@ Plugin::Plugin(const LXQt::PluginInfo &desktopFile, LXQt::Settings *settings, co
 Plugin::~Plugin()
 {
     delete mPlugin;
-    if (mPluginLoader)
-    {
-        mPluginLoader->unload();
-        delete mPluginLoader;
-    }
+    delete mPluginLoader;
 }
 
 void Plugin::setAlignment(Plugin::Alignment alignment)


### PR DESCRIPTION
The Qt "do not allow unload" patch
(https://codereview.qt-project.org/#/c/140750/) was postponed to Qt5.7

Discussion and agreement on not unloading libraries is here ->
http://lists.qt-project.org/pipermail/development/2015-November/023681.html
So plugins will not be unloadable in future Qt apps.

This solves e.g. mount plugin SEGFAULT described
https://github.com/lxde/lxqt/issues/1013#issuecomment-209793407.