### PR TITLE
Fix segfault on plugin initialization

### DIFF
--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -85,7 +85,6 @@ Plugin::Plugin(const LXQt::PluginInfo &desktopFile, LXQt::Settings *settings, co
     mPanel(panel)
 {
     mSettings = PluginSettingsFactory::create(settings, settingsGroup);
-    connect(mSettings, SIGNAL(settingsChanged()), this, SLOT(settingsChanged()));
 
     setWindowTitle(desktopFile.name());
     mName = desktopFile.name();
@@ -155,6 +154,10 @@ Plugin::Plugin(const LXQt::PluginInfo &desktopFile, LXQt::Settings *settings, co
         layout->addWidget(mPluginWidget, 0, 0);
     }
 
+    // delay the connection to settingsChanged to avoid conflicts
+    // while the plugin is still being initialized
+    connect(mSettings, &PluginSettings::settingsChanged,
+            this, &Plugin::settingsChanged);
     saveSettings();
 }
 


### PR DESCRIPTION
The plugins should only be connected to their settings' reset signal after they have been properly initialized.

Fixes lxde/lxqt#1031.