### PR TITLE
Clean up CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,6 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-no-undefined")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 #########################################################################
 
 add_definitions (-Wall)


### PR DESCRIPTION
The `-std` option is set on line 18 or line 20; no need to set it twice.