### PR TITLE
plugin-volume: Avoid an buffer overflow

### DIFF
--- a/plugin-volume/alsaengine.cpp
+++ b/plugin-volume/alsaengine.cpp
@@ -130,6 +130,7 @@ void AlsaEngine::discoverDevices()
 {
     int error;
     int cardNum = -1;
+    const int BUFF_SIZE = 64;
 
     while (1) {
         if ((error = snd_card_next(&cardNum)) < 0) {
@@ -140,8 +141,12 @@ void AlsaEngine::discoverDevices()
         if (cardNum < 0)
             break;
 
-        char str[64];
-        sprintf(str, "hw:%i", cardNum);
+        char str[BUFF_SIZE];
+        const size_t n = snprintf(str, sizeof(str), "hw:%i", cardNum);
+        if (BUFF_SIZE <= n) {
+            qWarning("AlsaEngine::discoverDevices: Buffer too small\n");
+            continue;
+        }
 
         snd_ctl_t *cardHandle;
         if ((error = snd_ctl_open(&cardHandle, str, 0)) < 0) {


### PR DESCRIPTION
sprintf() should not be used. snprintf() should be used for string
construction with explicit length checking.