### PR TITLE
Fix popup position of right click's menu of lxqt-panel's status notifier items

### DIFF
--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -270,7 +270,7 @@ void StatusNotifierButton::mouseReleaseEvent(QMouseEvent *event)
         if (mMenu)
         {
             mPlugin->willShowWindow(mMenu);
-            mMenu->popup(QCursor::pos());
+            mMenu->popup(mPlugin->panel()->calculatePopupWindowPos(QCursor::pos(), mMenu->sizeHint()).topLeft());
         } else
             interface->ContextMenu(QCursor::pos().x(), QCursor::pos().y());
     }


### PR DESCRIPTION
As discussed in https://github.com/lxde/lxqt-panel/commit/636838fe2cd9b68da446405c8d2f3b81af16a7e5#commitcomment-17137712.