### PR TITLE
Remove (extranous?) m->setParent(menu)

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1027,7 +1027,6 @@ void LXQtPanel::showPopupMenu(Plugin *plugin)
                 action->setDisabled(mLockPanel);
                 menu->addAction(action);
             }
-            qobject_cast<QObject*>(m)->setParent(menu);
         }
     }
 


### PR DESCRIPTION
I did a build of QT 5.5.1 on FreeBSD with WITH_DEBUG=YES in /etc/make.conf. This causes the macro Q_ASSERT to be expanded in QT sources. One assert is that the object on which setParent is called, must have isWidget set to a true value, [(1)](http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobject.cpp?h=v5.5.1#n1932) , which defaults to false [(2)](http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobject.cpp?h=v5.5.1#n205) for a QObject. After looking at the code, I do not get why the setParent is called. So I removed it, and AFAICT the plugins popUpMenus are  working as intended (without a failing assert on debug builds.)

[1] http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobject.cpp?h=v5.5.1#n1932
[2] http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobject.cpp?h=v5.5.1#n205