### PR TITLE
Statusnotifier: Remove setParent on StatusNotifierMenu.

### DIFF
--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -73,7 +73,6 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
         if (!path.path().isEmpty())
         {
             mMenu = (new MenuImporter{interface->service(), path.path(), this})->menu();
-            dynamic_cast<QObject &>(*mMenu).setParent(this);
             mMenu->setObjectName(QLatin1String("StatusNotifierMenu"));
         }
     });


### PR DESCRIPTION
I noticed the same issue as for the previous pull request https://github.com/lxde/lxqt-panel/pull/359, an extraneous setParent() call on a menu (as a QObject) see [https://github.com/lxde/lxqt-panel/commit/aed01a20eb4b4503ccc7bfa87a86573d4fe48163](https://github.com/lxde/lxqt-panel/commit/aed01a20eb4b4503ccc7bfa87a86573d4fe48163) I did not discover it before because I did not have any applications using the status notifier, and with qt5.5.1 build with debug. I assume that this menu is also correctly destroyed by 

palinek:
> DBusMenuImporter's destructor -> http://bazaar.launchpad.net/~dbusmenu-team/libdbusmenu-qt/trunk/view/head:/src/dbusmenuimporter.cpp#L364

The same Q_ASSERT as in https://github.com/lxde/lxqt-panel/pull/359 is giving troubles for instance when https://github.com/pvanek/qlipper is running. (or the battery status from lxqt-powermanager)

This seems to be the last setParent call on a non QWidget in the [codebase](https://github.com/search?utf8=%E2%9C%93&q=org%3Alxde+setParent%28&type=Code&ref=searchresults)