### PR TITLE
plugin: Fix crossreferencing of config dialogs

### DIFF
--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -42,6 +42,7 @@
 #include <QMenu>
 #include <QMouseEvent>
 #include <QApplication>
+#include <QWindow>
 #include <memory>
 
 #include <LXQt/Settings>
@@ -447,6 +448,10 @@ void Plugin::showConfigureDialog()
     mConfigDialog->show();
     mConfigDialog->raise();
     mConfigDialog->activateWindow();
+
+    WId wid = mConfigDialog->windowHandle()->winId();
+    KWindowSystem::activateWindow(wid);
+    KWindowSystem::setOnDesktop(wid, KWindowSystem::currentDesktop());
 }
 
 

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -436,24 +436,17 @@ void Plugin::realign()
  ************************************************/
 void Plugin::showConfigureDialog()
 {
-    // store a pointer to each plugin using the plugins' names
-    static QHash<QString, QPointer<QDialog> > refs;
-    QDialog *dialog = refs[name()].data();
+    if (!mConfigDialog)
+        mConfigDialog = mPlugin->configureDialog();
 
-    if (!dialog)
-    {
-        dialog = mPlugin->configureDialog();
-        refs[name()] = dialog;
-        connect(this, SIGNAL(destroyed()), dialog, SLOT(close()));
-    }
-
-    if (!dialog)
+    if (!mConfigDialog)
         return;
 
-    mPanel->willShowWindow(dialog);
-    dialog->show();
-    dialog->raise();
-    dialog->activateWindow();
+    connect(this, &Plugin::destroyed, mConfigDialog, &QWidget::close);
+    mPanel->willShowWindow(mConfigDialog);
+    mConfigDialog->show();
+    mConfigDialog->raise();
+    mConfigDialog->activateWindow();
 }
 
 

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -31,6 +31,7 @@
 
 #include <QFrame>
 #include <QString>
+#include <QPointer>
 #include <LXQt/PluginInfo>
 #include <LXQt/Settings>
 #include "ilxqtpanel.h"
@@ -113,6 +114,7 @@ private:
     LXQtPanel *mPanel;
     static QColor mMoveMarkerColor;
     QString mName;
+    QPointer<QDialog> mConfigDialog; //!< plugin's config dialog (if any)
 
 private slots:
     void settingsChanged();


### PR DESCRIPTION
Using the global (name indexed) map for storing configuration dialogs
of plugins wasn't a good idea:
1. plugins in different panels can (and will) have equal name
2. there's no need to search for existing pointer, when we can store it
directly

So with the old implementation we can end in activativation of dialog
belonging to different plugin in different panel.


Steps to reproduce the old/wrong behaviour:
- create two panels, each with e.g. clock plugin
- in confguration dialog of each panel check, that the names are equal (e.g. `clock`)
- invoke configuration dialog of clock in panel A via the context menu
- try to invoke configuration dialog of clock in panel B via the context menu

=> the pre-existing configuration dialog of clock in panel A will just be shown and the configuration dialog of clock in panel B can't be shown until the one from panel A isn't closed

(actualy this cross showing can also lead to crash on QASSERT in `WindowNotifier`)
