### PR TITLE
Don't rely on QIcon::hasThemeIcon to check icon existence

### DIFF
--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -136,9 +136,8 @@ void StatusNotifierButton::refetchIcon(Status status)
         QIcon nextIcon;
         if (!iconName.isEmpty())
         {
-            if (QIcon::hasThemeIcon(iconName))
-                nextIcon = QIcon::fromTheme(iconName);
-            else
+            nextIcon = QIcon::fromTheme(iconName);
+            if (nextIcon.isNull())
             {
                 QDir themeDir(mThemePath);
                 if (themeDir.exists())


### PR DESCRIPTION
Because of a bug in libqtxdg's icon loader engine, `QIcon::hasThemeIcon` always returns `true` and that makes sni-qt apps icon-less in the statusnotifier plugin. sni-qt-powered apps don't use theme icons, but
specific icons in temporary folders.

This depends on lxde/libqtxdg#97 and fixes lxde/lxqt#1081.