### PR TITLE
Add XKB_COMMON_INCLUDEDIR

### DIFF
--- a/plugin-kbindicator/CMakeLists.txt
+++ b/plugin-kbindicator/CMakeLists.txt
@@ -35,6 +35,7 @@ pkg_check_modules(XKB_COMMON_X11 QUIET xkbcommon-x11)
 
 if(XKB_COMMON_X11_FOUND)
     message(STATUS "XkbCommon X11 was found")
+    include_directories(${XKB_COMMON_X11_INCLUDE_DIRS})
     find_package(Qt5 COMPONENTS X11Extras Xml)
     pkg_check_modules(XCB xcb)
     pkg_check_modules(XCB_XKB xcb-xkb)


### PR DESCRIPTION
Add the standard directory.

Without this I get:
```
[   80s] cd "/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/build/plugin-mount" && /usr/bin/c++   -DLXQT_DATA_DIR=\"/usr/share\" -DLXQT_ETC_XDG_DIR=\"/etc/xdg\" -DLXQT_GRAPHICS_DIR=\"/usr/share/lxqt/graphics\" -DLXQT_RELATIVE_SHARE_DIR=\"lxqt\" -DLXQT_RELATIVE_SHARE_TRANSLATIONS_DIR=\"lxqt/translations\" -DLXQT_SHARE_DIR=\"/usr/share/lxqt\" -DLXQT_SHARE_TRANSLATIONS_DIR=\"/usr/share/lxqt/translations\" -DLXQT_VERSION=\"0.10.0\" -DPLUGIN_DIR=\"/usr/lib64/lxqt-panel\" -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_X11EXTRAS_LIB -DQT_XML_LIB -DWITH_CLOCK_PLUGIN -DWITH_DESKTOPSWITCH_PLUGIN -DWITH_MAINMENU_PLUGIN -Dmount_EXPORTS -I"/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/build/plugin-mount" -I"/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/plugin-mount" -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/lxqt -isystem /usr/include/lxqt/LXQt -isystem /usr/include/KF5/KWindowSystem -isystem /usr/include/KF5 -isystem /usr/include/qt5/QtDBus -isystem /usr/include/qt5/QtX11Extras -isystem /usr/include/qt5xdg -isystem /usr/include/qt5/QtXml -isystem /usr/include/qt5xdgiconloader -isystem /usr/include/qt5xdgiconloader/1.3.0 -isystem /usr/include/qt5/QtSvg -isystem /usr/include/KF5/Solid  -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -DNDEBUG -std=c++11 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -fPIC   -Wall -fPIC -o CMakeFiles/mount.dir/actions/deviceaction_nothing.cpp.o -c "/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/plugin-mount/actions/deviceaction_nothing.cpp"
[   80s] [ 36%] Building CXX object plugin-kbindicator/CMakeFiles/kbindicator.dir/src/x11/kbdlayout.cpp.o
[   80s] cd "/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/build/plugin-kbindicator" && /usr/bin/c++   -DLXQT_DATA_DIR=\"/usr/share\" -DLXQT_ETC_XDG_DIR=\"/etc/xdg\" -DLXQT_GRAPHICS_DIR=\"/usr/share/lxqt/graphics\" -DLXQT_RELATIVE_SHARE_DIR=\"lxqt\" -DLXQT_RELATIVE_SHARE_TRANSLATIONS_DIR=\"lxqt/translations\" -DLXQT_SHARE_DIR=\"/usr/share/lxqt\" -DLXQT_SHARE_TRANSLATIONS_DIR=\"/usr/share/lxqt/translations\" -DLXQT_VERSION=\"0.10.0\" -DPLUGIN_DIR=\"/usr/lib64/lxqt-panel\" -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DQT_X11EXTRAS_LIB -DQT_XML_LIB -DWITH_CLOCK_PLUGIN -DWITH_DESKTOPSWITCH_PLUGIN -DX11_ENABLED -Dkbindicator_EXPORTS -I"/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/build/plugin-kbindicator" -I"/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/plugin-kbindicator" -isystem /usr/include/qt5 -isystem /usr/include/qt5/QtWidgets -isystem /usr/include/qt5/QtGui -isystem /usr/include/qt5/QtCore -isystem /usr/lib64/qt5/mkspecs/linux-g++ -isystem /usr/include/lxqt -isystem /usr/include/lxqt/LXQt -isystem /usr/include/KF5/KWindowSystem -isystem /usr/include/KF5 -isystem /usr/include/qt5/QtDBus -isystem /usr/include/qt5/QtX11Extras -isystem /usr/include/qt5xdg -isystem /usr/include/qt5/QtXml -isystem /usr/include/qt5xdgiconloader -isystem /usr/include/qt5xdgiconloader/1.3.0 -isystem /usr/include/qt5/QtSvg  -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -DNDEBUG -std=c++11 -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -fPIC   -Wall -fPIC -o CMakeFiles/kbindicator.dir/src/x11/kbdlayout.cpp.o -c "/home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/plugin-kbindicator/src/x11/kbdlayout.cpp"
[   80s] /home/abuild/rpmbuild/BUILD/lxqt-panel-0.10.0~git129.1c48664/plugin-kbindicator/src/x11/kbdlayout.cpp:34:37: fatal error: xkbcommon/xkbcommon-x11.h: No such file or directory
[   80s]  #include <xkbcommon/xkbcommon-x11.h>
[   80s]                                      ^
[   80s] compilation terminated.
```