### PR TITLE
Remove arbitrary limit of taskbar button width

### DIFF
--- a/plugin-taskbar/lxqttaskbarconfiguration.ui
+++ b/plugin-taskbar/lxqttaskbarconfiguration.ui
@@ -131,7 +131,7 @@
          <number>1</number>
         </property>
         <property name="maximum">
-         <number>500</number>
+         <number>2147483647</number>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
With that change maximal button width can be set so big,
that allows to fill taskbar with just one button.
(fluxbox-like)