### PR TITLE
panel: Add delayed showing (autohide) functionality.

### DIFF
--- a/panel/config/configpanelwidget.cpp
+++ b/panel/config/configpanelwidget.cpp
@@ -76,6 +76,7 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
     mOldHidable = mPanel->hidable();
 
     mOldAnimation = mPanel->animationTime();
+    mOldShowDelay = mPanel->showDelay();
 
     ui->spinBox_panelSize->setMinimum(PANEL_MINIMUM_SIZE);
     ui->spinBox_panelSize->setMaximum(PANEL_MAXIMUM_SIZE);
@@ -101,6 +102,7 @@ ConfigPanelWidget::ConfigPanelWidget(LXQtPanel *panel, QWidget *parent) :
     connect(ui->comboBox_position,          SIGNAL(activated(int)),         this, SLOT(positionChanged()));
     connect(ui->checkBox_hidable,           SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
     connect(ui->spinBox_animation,          SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
+    connect(ui->spinBox_showDelay,          SIGNAL(valueChanged(int)),      this, SLOT(editChanged()));
 
     connect(ui->checkBox_customFontColor,   SIGNAL(toggled(bool)),          this, SLOT(editChanged()));
     connect(ui->pushButton_customFontColor, SIGNAL(clicked(bool)),          this, SLOT(pickFontColor()));
@@ -127,6 +129,7 @@ void ConfigPanelWidget::reset()
     ui->checkBox_hidable->setChecked(mOldHidable);
 
     ui->spinBox_animation->setValue(mOldAnimation);
+    ui->spinBox_showDelay->setValue(mOldShowDelay);
 
     fillComboBox_alignment();
     ui->comboBox_alignment->setCurrentIndex(mOldAlignment + 1);
@@ -261,6 +264,7 @@ void ConfigPanelWidget::editChanged()
     mPanel->setPosition(mScreenNum, mPosition, true);
     mPanel->setHidable(ui->checkBox_hidable->isChecked(), true);
     mPanel->setAnimationTime(ui->spinBox_animation->value(), true);
+    mPanel->setShowDelay(ui->spinBox_showDelay->value(), true);
 
     mPanel->setFontColor(ui->checkBox_customFontColor->isChecked() ? mFontColor : QColor(), true);
     if (ui->checkBox_customBgColor->isChecked())

--- a/panel/config/configpanelwidget.h
+++ b/panel/config/configpanelwidget.h
@@ -90,6 +90,7 @@ private:
     ILXQtPanel::Position mOldPosition;
     bool mOldHidable;
     int mOldAnimation;
+    int mOldShowDelay;
     int mOldScreenNum;
     QColor mOldFontColor;
     QColor mOldBackgroundColor;

--- a/panel/config/configpanelwidget.ui
+++ b/panel/config/configpanelwidget.ui
@@ -234,7 +234,26 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="2" column="3">
+       <widget class="QSpinBox" name="spinBox_showDelay">
+        <property name="enabled">
+         <bool>false</bool>
+        </property> 
+        <property name="toolTip">
+         <string>Zero means no delay</string>
+        </property>
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="maximum">
+         <number>2000</number>
+        </property>
+        <property name="singleStep">
+         <number>50</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label_position">
         <property name="text">
          <string>Position:</string>
@@ -251,6 +270,19 @@
         </property>
         <property name="text">
          <string>Animation duration:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="label_showDelay">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Zero means no delay</string>
+        </property>
+        <property name="text">
+         <string>Delayed restoring:</string>
         </property>
        </widget>
       </item>
@@ -296,7 +328,7 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="1" colspan="3">
+      <item row="3" column="1" colspan="3">
        <widget class="QComboBox" name="comboBox_position"/>
       </item>
      </layout>
@@ -665,6 +697,38 @@
     <hint type="destinationlabel">
      <x>319</x>
      <y>198</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_hidable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_showDelay</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>70</x>
+     <y>209</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>211</x>
+     <y>242</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBox_hidable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>spinBox_showDelay</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>70</x>
+     <y>211</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>340</x>
+     <y>242</y>
     </hint>
    </hints>
   </connection>

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -220,6 +220,7 @@ public:
     int opacity() const { return mOpacity; }
     bool hidable() const { return mHidable; }
     int animationTime() const { return mAnimationTime; }
+    int showDelay() const { return mShowDelay; }
 
     /*!
      * \brief Checks if a given Plugin is running and has the
@@ -234,20 +235,42 @@ public:
 public slots:
     /**
      * @brief Shows the QWidget and makes it visible on all desktops. This
-     * method is NOT related to showPanel(), hidePanel() and hidePanelWork()
-     * which handle the LXQt hiding by resizing the panel.
+     * method is NOT related to showPanel(), showPanelWork(), doShowPanel(),
+     * hidePanel() and hidePanelWork() which handle the LXQt hiding by resizing
+     * the panel.
      */
     void show();
     /**
+     * @brief Shows the panel (delayed) by starting the QTimer mShowTimer.
+     * When this timer times out, showPanelWork() will be called. So this
+     * method is called when the cursor hovers the panel area but the panel
+     * will be shown later. This methods cancel (stops) a previous QTimer
+     * mHideTimer.
+     *
+     * \sa mHidable, mHidden, mShowTimer, mShowDelay, showPanelWork(), hidePanel()
+     */
+    void showPanel();
+    /**
+     * @brief Actually starts the action to show the panel. Will be invoked
+     * when the QTimer mShowTimer times out. That timer will be started by
+     * showPanel. This is NOT the same as QWidget::show() because hiding the
+     * panel in LXQt is done by making it very thin. So this method in fact
+     * calls the restoration of the original size of the panel (actually
+     * done by doShowPanel()).
+     *
+     * \sa mHidable, mHidden, mShowTimer, mShowDelay, showPanel(), doShowPanel()
+     */
+    void showPanelWork();
+    /**
      * @brief Shows the panel (immediately) after it had been hidden before.
-     * Stops the QTimer mHideTimer. This it NOT the same as QWidget::show()
-     * because hiding the panel in LXQt is done by making it very thin. So
-     * this method in fact restores the original size of the panel.
+     * This it NOT the same as QWidget::show() because hiding the panel in LXQt
+     * is done by making it very thin. So this method in fact restores the
+     * original size of the panel.
      * \param animate flag for the panel show-up animation disabling (\sa mAnimationTime).
      *
-     * \sa mHidable, mHidden, mHideTimer, hidePanel(), hidePanelWork()
+     * \sa mHidable, mHidden, mShowTimer, mShowDelay, showPanel(), showPanelWork()
      */
-    void showPanel(bool animate);
+    void doShowPanel(bool animate);
     /**
      * @brief Hides the panel (delayed) by starting the QTimer mHideTimer.
      * When this timer times out, hidePanelWork() will be called. So this
@@ -259,7 +282,7 @@ public slots:
     void hidePanel();
     /**
      * @brief Actually hides the panel. Will be invoked when the QTimer
-     * mHideTimer times out. That timer will be started by showPanel(). This
+     * mHideTimer times out. That timer will be started by hidePanel(). This
      * is NOT the same as QWidget::hide() because hiding the panel in LXQt is
      * done by making the panel very thin. So this method in fact makes the
      * panel very thin while the QWidget stays visible.
@@ -295,6 +318,7 @@ public slots:
     void setOpacity(int opacity, bool save); //!< \sa setPanelSize()
     void setHidable(bool hidable, bool save); //!< \sa setPanelSize()
     void setAnimationTime(int animationTime, bool save); //!< \sa setPanelSize()
+    void setShowDelay(int showDelay, bool save); //!< \sa setPanelSize()
 
     /**
      * @brief Saves the current configuration, i.e. writes the current
@@ -614,11 +638,27 @@ private:
      */
     QTimer mHideTimer;
     /**
+     * @brief QTimer for showing the panel. When the cursor is over the hidden
+     * panel area, this timer will be started. If the cursor leaves the hidden
+     * panel area, this timer will be stopped and reset. After this timer has
+     * timed out, the panel will actually be shown.
+     *
+     * \sa mHidable, mHidden, showPanel(), showPanelWork(), doShowPanel()
+     */
+    QTimer mShowTimer;
+    /**
      * @brief Stores the duration of auto-hide animation.
      *
      * \sa mHidden, mHideTimer, showPanel(), hidePanel(), hidePanelWork()
      */
     int mAnimationTime;
+    /**
+     * @brief Stores the duration of waiting time before actually restoring the
+     * panel.
+     *
+     * \sa mHidden, showPanel(), showPanelWork(), doShowPanel()
+     */
+    int mShowDelay;
 
     QColor mFontColor; //!< Font color that is used in the style sheet.
     QColor mBackgroundColor; //!< Background color that is used in the style sheet.


### PR DESCRIPTION
I added, to the autohide functionality, the possibility to "un-hide" a panel if the the pointer (mouse/touchpad) reaches the panel and stays over there a few milliseconds.
It's annoying to have shown a panel when accidentally the mouse reaches the hidden panel. I, personally, do prefer waiting a few milliseconds when I actually want to show it. 600 milliseconds are ok in my case, but I added a configurable property.
The choosen property name does not convince me. Current commits says "Delayed showing" in the panel configuration, but I am open to alternative names (maybe "Delayed unhiding"? I am sorry, English is not my native language.).
