### PR TITLE
taskbar: avoid icon-only for new group windows

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -298,8 +298,9 @@ void LXQtTaskBar::addWindow(WId window)
         });
 
         mLayout->addWidget(group);
-        group->setToolButtonsStyle(mButtonStyle);
     }
+
+    group->setToolButtonsStyle(mButtonStyle);
 
     mKnownWindows[window] = group;
     group->addWindow(window);


### PR DESCRIPTION
Commit 2c8722 added the functionality to avoid showing only icons on groups
popups. But this feature was not complete since it only works when the
plugin-taskbar configuration is setted to "Only Icons", newly added windows
will display as a single icon.

This commit fixes this behavior for every new window.

Signed-off-by: Bruno Ribas <brunoribas@gmail.com>