### PR TITLE
plugin-desktopswitch: Add LABEL_TYPE_NONE

### DIFF
--- a/plugin-desktopswitch/desktopswitchbutton.cpp
+++ b/plugin-desktopswitch/desktopswitchbutton.cpp
@@ -51,6 +51,12 @@ void DesktopSwitchButton::update(int index, LabelType labelType, const QString &
             setText(title);
             break;
 
+        // A blank space was used in NONE Label Type as it uses less space
+        // for each desktop button at the panel
+        case LABEL_TYPE_NONE:
+            setText(QStringLiteral(" "));
+            break;
+
         default: // LABEL_TYPE_NUMBER
             setText(QString::number(index + 1));
     }

--- a/plugin-desktopswitch/desktopswitchbutton.h
+++ b/plugin-desktopswitch/desktopswitchbutton.h
@@ -44,7 +44,8 @@ class DesktopSwitchButton : public QToolButton
 public:
     enum LabelType { // Must match with combobox indexes
         LABEL_TYPE_NUMBER = 0,
-        LABEL_TYPE_NAME = 1
+        LABEL_TYPE_NAME = 1,
+        LABEL_TYPE_NONE = 2
     };
 
     DesktopSwitchButton(QWidget * parent, int index, LabelType labelType, const QString &title=QString());

--- a/plugin-desktopswitch/desktopswitchconfiguration.ui
+++ b/plugin-desktopswitch/desktopswitchconfiguration.ui
@@ -59,6 +59,11 @@
           <string>Names</string>
          </property>
         </item>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
When the user doesn't want to show numbers or workspaces names (specially
when using multi row display at the switcher) but want to keep workspaces
names.

A "None" option was added to display no text at the desktop switcher.

Signed-off-by: Bruno Ribas brunoribas@gmail.com
