### PR TITLE
Use the new lxqt-build-tools CMake modules (FindMenuCache)

### DIFF
--- a/plugin-mainmenu/CMakeLists.txt
+++ b/plugin-mainmenu/CMakeLists.txt
@@ -18,28 +18,28 @@ set(UIS
     lxqtmainmenuconfiguration.ui
 )
 
+
 # optionally use libmenu-cache to generate the application menu
-find_package(PkgConfig)
 if(NOT WITHOUT_MENU_CACHE)
-    pkg_check_modules(MENU_CACHE
-        libmenu-cache>=0.3.3
-    )
-endif()
-
-if(MENU_CACHE_FOUND)
-    list(APPEND SOURCES xdgcachedmenu.cpp)
-    list(APPEND MOCS xdgcachedmenu.h)
-
-    include_directories(${MENU_CACHE_INCLUDE_DIRS})
-    add_definitions(-DHAVE_MENU_CACHE=1)
+    find_package(MenuCache "0.3.3")
 endif()
 
 set(LIBRARIES
     lxqt
     lxqt-globalkeys
     lxqt-globalkeys-ui
-    ${MENU_CACHE_LIBRARIES}
 )
+
+if(MENUCACHE_FOUND)
+    list(APPEND SOURCES xdgcachedmenu.cpp)
+    list(APPEND MOCS xdgcachedmenu.h)
+
+    include_directories(${MENUCACHE_INCLUDE_DIRS})
+    list(APPEND LIBRARIES ${MENUCACHE_LIBRARIES})
+    add_definitions(-DHAVE_MENU_CACHE=1)
+
+endif()
+
 
 set(QT_USE_QTXML 1)
 set(QT_USE_QTDBUS 1)


### PR DESCRIPTION
Improved non standard location detection.
Drop the use of empty entries in LIBRARIES. If MenuCache is not found then
MENUCACHE_LIBRARIES is empty and CMake is picky about it now.