### PR TITLE
Fix hiding of panel with drag

### DIFF
--- a/panel/ilxqtpanel.h
+++ b/panel/ilxqtpanel.h
@@ -110,6 +110,13 @@ public:
      *
      */
     virtual void willShowWindow(QWidget * w) = 0;
+
+    /*!
+     * \brief This function checks if the cursor is not inside panel and then hides an auto-hide panel
+     * after stopping its delayed show timer.
+     *
+     */
+    virtual void hideOnCursorLeave() = 0;
 };
 
 #endif // ILXQTPANEL_H

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1257,6 +1257,15 @@ void LXQtPanel::hidePanel()
         mHideTimer.start();
 }
 
+void LXQtPanel::hideOnCursorLeave()
+{
+    if (!geometry().contains(QCursor::pos(), true))
+    {
+        mShowDelayTimer.stop();
+        hidePanel();
+    }
+}
+
 void LXQtPanel::hidePanelWork()
 {
     if (!geometry().contains(QCursor::pos()))

--- a/panel/lxqtpanel.h
+++ b/panel/lxqtpanel.h
@@ -146,6 +146,7 @@ public:
     QRect calculatePopupWindowPos(QPoint const & absolutePos, QSize const & windowSize) const override;
     QRect calculatePopupWindowPos(const ILXQtPanelPlugin *plugin, const QSize &windowSize) const override;
     void willShowWindow(QWidget * w) override;
+    void hideOnCursorLeave() override;
     // ........ end of ILXQtPanel overrides
 
     /**

--- a/plugin-quicklaunch/lxqtquicklaunch.cpp
+++ b/plugin-quicklaunch/lxqtquicklaunch.cpp
@@ -184,6 +184,13 @@ void LXQtQuickLaunch::dragEnterEvent(QDragEnterEvent *e)
 }
 
 
+void LXQtQuickLaunch::dragLeaveEvent(QDragLeaveEvent *e)
+{
+    QFrame::dragLeaveEvent(e);
+    mPlugin->panel()->hideOnCursorLeave();
+}
+
+
 void LXQtQuickLaunch::dropEvent(QDropEvent *e)
 {
     const QMimeData *mime = e->mimeData();

--- a/plugin-quicklaunch/lxqtquicklaunch.h
+++ b/plugin-quicklaunch/lxqtquicklaunch.h
@@ -69,6 +69,7 @@ private:
     QLabel *mPlaceHolder;
 
     void dragEnterEvent(QDragEnterEvent *e);
+    void dragLeaveEvent(QDragLeaveEvent *e);
     void dropEvent(QDropEvent *e);
 
     void saveSettings();


### PR DESCRIPTION
If something is dragged into the 4-pix zone of an auto-hiding panel, the panel will be shown but, in case it contains the quick launch widget, if the dragging cursor enters the child widget, `QEvent::DragLeave` will be sent for the panel, so that `QEvent::DragLeave` won't be sent again if the cursor leaves the child widget and the panel *simultaneously*. As a result, the panel won't be hidden in such cases (until an ordinary cursor enters and leaves it).

This patch fixes the above-mentioned situation with a new (virtual) method, namely `hideOnCursorLeave()`, which is called by `LXQtQuickLaunch::dragLeaveEvent()`. The function checks if the cursor is outside the interior of the panel (on its boundary) and only then, stops the delayed show timer and hides the panel.

The same method may be needed to be applied for other DND-enabled widgets. This is only for quick launcher.