### PR TITLE
panel: Hide correctly upon the DragLeave

### DIFF
--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -388,7 +388,10 @@ void LXQtPanel::loadPlugins()
     connect(mPlugins.data(), &PanelPluginsModel::pluginRemoved, this, &LXQtPanel::pluginRemoved);
 
     for (auto const & plugin : mPlugins->plugins())
+    {
         mLayout->addPlugin(plugin);
+        connect(plugin, &Plugin::dragLeft, [this] { mShowDelayTimer.stop(); hidePanel(); });
+    }
 }
 
 /************************************************

--- a/panel/plugin.h
+++ b/panel/plugin.h
@@ -81,6 +81,8 @@ public:
 
     QString name() const { return mName; }
 
+    virtual bool eventFilter(QObject * watched, QEvent * event);
+
     // For QSS properties ..................
     static QColor moveMarkerColor() { return mMoveMarkerColor; }
     static void setMoveMarkerColor(QColor color) { mMoveMarkerColor = color; }
@@ -93,6 +95,11 @@ public slots:
 signals:
     void startMove();
     void remove();
+    /*!
+     * \brief Signal emitted when this widget or some of its children
+     * get the DragLeave event delivered.
+     */
+    void dragLeft();
 
 protected:
     void contextMenuEvent(QContextMenuEvent *event);
@@ -104,6 +111,8 @@ private:
     bool loadLib(ILXQtPanelPluginLibrary const * pluginLib);
     bool loadModule(const QString &libraryName);
     ILXQtPanelPluginLibrary const * findStaticPlugin(const QString &libraryName);
+    void watchWidgets(QObject * const widget);
+    void unwatchWidgets(QObject * const widget);
 
     const LXQt::PluginInfo mDesktopFile;
     QPluginLoader *mPluginLoader;


### PR DESCRIPTION
The DragLeave event is not delivered to the parent widget while DND and
the cursor leaves the parent and child (which also observes drag
events) simulatenously.

The panel needs to know about the DragLeave event (to correctly hide)
even if there is no spare space between the child plugin and the panel
edge.

So we're observing the DragLeave events for all the plugins and its
children widgets.

---

1. With this we don't need to do anything special in particular plugins.
2. At first look it seemed to me as a bad idea to observe all the children (and its children ..) objects/widgets, but a simple check with `callgrind` is showing zero time spent in the `Plugin::eventFilter()`
3. We probably can't extend this logic to remove the `willShowWindow()` logic, because in case of standalone windows they mostly aren't children of plugins/panel.

@tsujan can you, please, have a look on this and optionally summarize the pros/cons by confronting it with your solution in #388 
