### PR TITLE
volume: Fix reporting of pulse volume

### DIFF
--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -209,7 +209,7 @@ void PulseAudioEngine::addOrUpdateSink(const pa_sink_info *info)
 
     pa_volume_t v = pa_cvolume_avg(&(info->volume));
     // convert real volume to percentage
-    dev->setVolumeNoCommit(((double)v * 100.0) / m_maximumVolume);
+    dev->setVolumeNoCommit(qRound((static_cast<double>(v) * 100.0) / m_maximumVolume));
 
     if (newSink) {
         //keep the sinks sorted by index()


### PR DESCRIPTION
While recalculating volume to percentage the result wasn't correctly
rounded. This caused the information held by plugin volume be out of
sync with actual device state.
Then adjusting the volume by plugin-volume behaved strange.

ref lxde/lxqt#1263