### PR TITLE
Fix mouse wheel and cursor on Volume plugin

### DIFF
--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -119,8 +119,7 @@ void VolumeButton::mouseReleaseEvent(QMouseEvent *event)
 
 void VolumeButton::mouseMoveEvent(QMouseEvent *event)
 {
-    if (!toolTip().isEmpty())
-        QToolTip::showText(event->globalPos(), toolTip());
+    QToolTip::showText(event->globalPos(), toolTip());
     QToolButton::mouseMoveEvent(event);
 }
 

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -33,6 +33,7 @@
 #include <QSlider>
 #include <QMouseEvent>
 #include <QProcess>
+#include <QToolTip>
 
 #include <XdgIcon>
 #include "../panel/ilxqtpanel.h"
@@ -46,6 +47,7 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         m_muteOnMiddleClick(true)
 {
     setAutoRaise(true);
+    setMouseTracking(true);
     // initial icon for button. It will be replaced after devices scan.
     // In the worst case - no soundcard/pulse - is found it remains
     // in the button but at least the button is not blank ("invisible")
@@ -113,6 +115,13 @@ void VolumeButton::mouseReleaseEvent(QMouseEvent *event)
     }
 
     QToolButton::mouseReleaseEvent(event);
+}
+
+void VolumeButton::mouseMoveEvent(QMouseEvent *event)
+{
+    if (!toolTip().isEmpty())
+        QToolTip::showText(event->globalPos(), toolTip());
+    QToolButton::mouseMoveEvent(event);
 }
 
 void VolumeButton::toggleVolumeSlider()

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -58,6 +58,7 @@ protected:
     void leaveEvent(QEvent *event);
     void wheelEvent(QWheelEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
+    void mouseMoveEvent(QMouseEvent *event);
 
 private slots:
     void toggleVolumeSlider();

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -183,9 +183,7 @@ void VolumePopup::openAt(QPoint pos, Qt::Corner anchor)
 
 void VolumePopup::handleWheelEvent(QWheelEvent *event)
 {
-    int delta = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep;
-    m_volumeSlider->setValue(m_volumeSlider->value() + delta * m_volumeSlider->singleStep());
-    QTimer::singleShot(0, this, [this] {QToolTip::showText(QCursor::pos(),  m_volumeSlider->toolTip());});
+    m_volumeSlider->event(reinterpret_cast<QEvent*>(event));
 }
 
 void VolumePopup::setDevice(AudioDevice *device)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -177,7 +177,11 @@ void VolumePopup::openAt(QPoint pos, Qt::Corner anchor)
 
 void VolumePopup::handleWheelEvent(QWheelEvent *event)
 {
-    m_volumeSlider->event(reinterpret_cast<QEvent*>(event));
+    int delta = event->angleDelta().y() / 120.f;
+    m_volumeSlider->setValue(m_volumeSlider->value() + delta * m_volumeSlider->singleStep());
+    QTimer::singleShot(0, this, [this] {QToolTip::showText(QCursor::pos(), 
+                                        m_volumeSlider->toolTip(),
+                                        m_volumeSlider);});
 }
 
 void VolumePopup::setDevice(AudioDevice *device)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -41,6 +41,13 @@
 #include "audioengine.h"
 #include <QDebug>
 
+void Slider::wheelEvent(QWheelEvent *event)
+{
+    int delta = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep;
+    setValue(value() + delta * singleStep());
+    QTimer::singleShot(0, this, [this] {QToolTip::showText(QCursor::pos(), toolTip());});
+}
+
 VolumePopup::VolumePopup(QWidget* parent):
     QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::Popup | Qt::X11BypassWindowManagerHint),
     m_pos(0,0),
@@ -54,7 +61,7 @@ VolumePopup::VolumePopup(QWidget* parent):
     m_mixerButton->setText(tr("Mi&xer"));
     m_mixerButton->setAutoDefault(false);
 
-    m_volumeSlider = new QSlider(Qt::Vertical, this);
+    m_volumeSlider = new Slider(Qt::Vertical, this);
     m_volumeSlider->setTickPosition(QSlider::TicksBothSides);
     m_volumeSlider->setTickInterval(10);
     // the volume slider shows 0-100 and volumes of all devices
@@ -177,11 +184,9 @@ void VolumePopup::openAt(QPoint pos, Qt::Corner anchor)
 
 void VolumePopup::handleWheelEvent(QWheelEvent *event)
 {
-    int delta = event->angleDelta().y() / 120.f;
+    int delta = event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep;
     m_volumeSlider->setValue(m_volumeSlider->value() + delta * m_volumeSlider->singleStep());
-    QTimer::singleShot(0, this, [this] {QToolTip::showText(QCursor::pos(), 
-                                        m_volumeSlider->toolTip(),
-                                        m_volumeSlider);});
+    QTimer::singleShot(0, this, [this] {QToolTip::showText(QCursor::pos(),  m_volumeSlider->toolTip());});
 }
 
 void VolumePopup::setDevice(AudioDevice *device)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -31,7 +31,6 @@
 
 #include <XdgIcon>
 
-#include <QSlider>
 #include <QStyleOptionButton>
 #include <QPushButton>
 #include <QVBoxLayout>

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -29,10 +29,21 @@
 #define VOLUMEPOPUP_H
 
 #include <QDialog>
+#include <QSlider>
 
-class QSlider;
 class QPushButton;
 class AudioDevice;
+
+class Slider : public QSlider
+{
+    Q_OBJECT
+public:
+    Slider(Qt::Orientation orientation, QWidget *parent = 0)
+        : QSlider(orientation, parent){}
+
+protected:
+    void wheelEvent(QWheelEvent *event);
+};
 
 class VolumePopup : public QDialog
 {
@@ -74,7 +85,7 @@ private:
     void realign();
     void updateStockIcon();
 
-    QSlider *m_volumeSlider;
+    Slider *m_volumeSlider;
     QPushButton *m_mixerButton;
     QPushButton *m_muteToggleButton;
     QPoint m_pos;


### PR DESCRIPTION
(1) Make wheel follow the step set in the config;
(2) Show the tooltip immediately on hovering because a delay is annoying in this case;
(3) Show a tooltip immediately on scrolling the mouse wheel too.

With this, the mouse wheel can be used to change the volume comfortably.

This PR is based on https://github.com/lxde/lxqt-panel/pull/396.