### PR TITLE
volume: Fix calculating of alsa volume

### DIFF
--- a/plugin-volume/alsadevice.cpp
+++ b/plugin-volume/alsadevice.cpp
@@ -30,7 +30,9 @@
 AlsaDevice::AlsaDevice(AudioDeviceType t, AudioEngine *engine, QObject *parent) :
     AudioDevice(t, engine, parent),
     m_mixer(0),
-    m_elem(0)
+    m_elem(0),
+    m_volumeMin(0),
+    m_volumeMax(100)
 {
 }
 
@@ -59,4 +61,10 @@ void AlsaDevice::setCardName(const QString &cardName)
 
     m_cardName = cardName;
     emit cardNameChanged();
+}
+
+void AlsaDevice::setVolumeMinMax(long volumeMin, long volumeMax)
+{
+    m_volumeMin = volumeMin;
+    m_volumeMax = volumeMax;
 }

--- a/plugin-volume/alsadevice.h
+++ b/plugin-volume/alsadevice.h
@@ -45,10 +45,13 @@ public:
     snd_mixer_t *mixer() const { return m_mixer; }
     snd_mixer_elem_t *element() const { return m_elem; }
     const QString &cardName() const { return m_cardName; }
+    inline long volumeMin() const { return m_volumeMin; }
+    inline long volumeMax() const { return m_volumeMax; }
 
     void setMixer(snd_mixer_t *mixer);
     void setElement(snd_mixer_elem_t *elem);
     void setCardName(const QString &cardName);
+    void setVolumeMinMax(long volumeMin, long volumeMax);
 
 signals:
     void mixerChanged();
@@ -59,6 +62,8 @@ private:
     snd_mixer_t *m_mixer;
     snd_mixer_elem_t *m_elem;
     QString m_cardName;
+    long m_volumeMin;
+    long m_volumeMax;
 };
 
 #endif // ALSADEVICE_H

--- a/plugin-volume/alsaengine.cpp
+++ b/plugin-volume/alsaengine.cpp
@@ -63,9 +63,9 @@ AlsaEngine *AlsaEngine::instance()
 
 int AlsaEngine::volumeMax(AudioDevice *device) const
 {
-    // We already did snd_mixer_selem_set_playback_volume_range(mixerElem, 0, 100);
-    // during initialization. So we can return 100 directly here.
-    return 100;
+    AlsaDevice * alsa_dev = qobject_cast<AlsaDevice *>(device);
+    Q_ASSERT(alsa_dev);
+    return alsa_dev->volumeMax();
 }
 
 AlsaDevice *AlsaEngine::getDeviceByAlsaElem(snd_mixer_elem_t *elem) const
@@ -88,7 +88,7 @@ void AlsaEngine::commitDeviceVolume(AudioDevice *device)
     if (!dev || !dev->element())
         return;
 
-    long value = dev->volume();
+    long value = dev->volumeMin() + qRound(static_cast<double>(dev->volume()) / 100.0 * (dev->volumeMax() - dev->volumeMin()));
     snd_mixer_selem_set_playback_volume_all(dev->element(), value);
 }
 
@@ -112,7 +112,7 @@ void AlsaEngine::updateDevice(AlsaDevice *device)
     long value;
     snd_mixer_selem_get_playback_volume(device->element(), (snd_mixer_selem_channel_id_t)0, &value);
     // qDebug() << "updateDevice:" << device->name() << value;
-    device->setVolumeNoCommit(value);
+    device->setVolumeNoCommit(qRound((static_cast<double>(value - device->volumeMin()) * 100.0) / (device->volumeMax() - device->volumeMin())));
 
     if (snd_mixer_selem_has_playback_switch(device->element())) {
         int mute;
@@ -198,8 +198,10 @@ void AlsaEngine::discoverDevices()
                     dev->setMixer(mixer);
                     dev->setElement(mixerElem);
 
-                    // set the range of volume to 0-100
-                    snd_mixer_selem_set_playback_volume_range(mixerElem, 0, 100);
+                    // get & store the range
+                    long min, max;
+                    snd_mixer_selem_get_playback_volume_range(mixerElem, &min, &max);
+                    dev->setVolumeMinMax(min, max);
 
                     updateDevice(dev);
 

--- a/plugin-volume/alsaengine.cpp
+++ b/plugin-volume/alsaengine.cpp
@@ -200,16 +200,8 @@ void AlsaEngine::discoverDevices()
 
                     // set the range of volume to 0-100
                     snd_mixer_selem_set_playback_volume_range(mixerElem, 0, 100);
-                    long value;
-                    snd_mixer_selem_get_playback_volume(mixerElem, (snd_mixer_selem_channel_id_t)0, &value);
-                    // qDebug() << dev->name() << "initial volume" << value;
-                    dev->setVolumeNoCommit(value);
 
-                    if (snd_mixer_selem_has_playback_switch(mixerElem)) {
-                        int mute;
-                        snd_mixer_selem_get_playback_switch(mixerElem, (snd_mixer_selem_channel_id_t)0, &mute);
-                        dev->setMuteNoCommit(!(bool)mute);
-                    }
+                    updateDevice(dev);
 
                     // register event callback
                     snd_mixer_elem_set_callback(mixerElem, alsa_elem_event_callback);


### PR DESCRIPTION
By changing the volume range for alsa mixer we lost the control over
(possible) rounding problems when setting the volume. So setting
volume to particular (mapped) value didn't necessarily result to that
value realy used by alsa (alsa's calculation mapped -> native and
native -> mapped didn't yield the same value).

Then adjusting the volume by plugin-volume sometimes behaved strange.


ref lxde/lxqt#1263