### PR TITLE
Elide texts of taskbar items when needed.

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.cpp
+++ b/plugin-taskbar/lxqttaskbutton.cpp
@@ -68,7 +68,8 @@ void LeftAlignedTextStyle::drawItemText(QPainter * painter, const QRect & rect, 
             , const QPalette & pal, bool enabled, const QString & text
             , QPalette::ColorRole textRole) const
 {
-    return QProxyStyle::drawItemText(painter, rect, (flags & ~Qt::AlignHCenter) | Qt::AlignLeft, pal, enabled, text, textRole);
+    QString txt = QFontMetrics(painter->font()).elidedText(text, Qt::ElideRight, rect.width());
+    return QProxyStyle::drawItemText(painter, rect, (flags & ~Qt::AlignHCenter) | Qt::AlignLeft, pal, enabled, txt, textRole);
 }
 
 


### PR DESCRIPTION
The current cut text is unprofessional.

The default left-alignedness was ugly too but I didn't touch it because I thought it should be a stylesheet job.