### PR TITLE
Volume fixes

### DIFF
--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -33,6 +33,7 @@
 #include <QSlider>
 #include <QMouseEvent>
 #include <QProcess>
+#include <QToolTip>
 
 #include <XdgIcon>
 #include "../panel/ilxqtpanel.h"
@@ -46,6 +47,7 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         m_muteOnMiddleClick(true)
 {
     setAutoRaise(true);
+    setMouseTracking(true);
     // initial icon for button. It will be replaced after devices scan.
     // In the worst case - no soundcard/pulse - is found it remains
     // in the button but at least the button is not blank ("invisible")
@@ -91,6 +93,20 @@ void VolumeButton::enterEvent(QEvent *event)
         showVolumeSlider();
 
     m_popupHideTimer.stop();
+}
+
+void VolumeButton::mouseMoveEvent(QMouseEvent *event)
+{
+    // moving the tooltip must be achieved by chaging the text
+    // (hide/show - won't work because of the internal hide delay)
+    QString tooltip = toolTip();
+    if (!tooltip.isEmpty())
+    {
+        *(tooltip.rbegin()) = 'X';
+        QToolTip::showText(event->globalPos(), tooltip);
+        QToolTip::showText(event->globalPos(), toolTip());
+    }
+    QToolButton::mouseMoveEvent(event);
 }
 
 void VolumeButton::leaveEvent(QEvent *event)

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -58,6 +58,7 @@ protected:
     void leaveEvent(QEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
 private slots:
     void toggleVolumeSlider();

--- a/plugin-volume/volumebutton.h
+++ b/plugin-volume/volumebutton.h
@@ -54,10 +54,10 @@ public slots:
     void showVolumeSlider();
 
 protected:
-    void enterEvent(QEvent *event);
-    void leaveEvent(QEvent *event);
-    void wheelEvent(QWheelEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
+    void enterEvent(QEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
 
 private slots:
     void toggleVolumeSlider();

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -61,6 +61,7 @@ VolumePopup::VolumePopup(QWidget* parent):
     // the volume slider shows 0-100 and volumes of all devices
     // should be converted to percentages.
     m_volumeSlider->setRange(0, 100);
+    m_volumeSlider->installEventFilter(this);
 
     m_muteToggleButton = new QPushButton(this);
     m_muteToggleButton->setIcon(XdgIcon::fromTheme(QStringList() << "audio-volume-muted"));
@@ -88,6 +89,20 @@ bool VolumePopup::event(QEvent *event)
         hide();
     }
     return QDialog::event(event);
+}
+
+bool VolumePopup::eventFilter(QObject * watched, QEvent * event)
+{
+    if (watched == m_volumeSlider)
+    {
+        if (event->type() == QEvent::Wheel)
+        {
+            handleWheelEvent(dynamic_cast<QWheelEvent *>(event));
+            return true;
+        }
+        return false;
+    }
+    return QDialog::eventFilter(watched, event);
 }
 
 void VolumePopup::enterEvent(QEvent *event)

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -107,9 +107,7 @@ void VolumePopup::handleSliderValueChanged(int value)
         return;
     // qDebug("VolumePopup::handleSliderValueChanged: %d\n", value);
     m_device->setVolume(value);
-    m_volumeSlider->setToolTip(QString("%1%").arg(value));
-    dynamic_cast<QWidget&>(*parent()).setToolTip(m_volumeSlider->toolTip()); //parent is the button on panel
-    QToolTip::showText(QCursor::pos(),  m_volumeSlider->toolTip(), m_volumeSlider);
+    QTimer::singleShot(0, this, [this] { QToolTip::showText(QCursor::pos(), m_volumeSlider->toolTip()); });
 }
 
 void VolumePopup::handleMuteToggleClicked()

--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -40,6 +40,7 @@
 #include <QToolTip>
 #include "audioengine.h"
 #include <QDebug>
+#include <QWheelEvent>
 
 VolumePopup::VolumePopup(QWidget* parent):
     QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::Popup | Qt::X11BypassWindowManagerHint),
@@ -177,7 +178,8 @@ void VolumePopup::openAt(QPoint pos, Qt::Corner anchor)
 
 void VolumePopup::handleWheelEvent(QWheelEvent *event)
 {
-    m_volumeSlider->event(reinterpret_cast<QEvent*>(event));
+    m_volumeSlider->setSliderPosition(m_volumeSlider->sliderPosition()
+            + (event->angleDelta().y() / QWheelEvent::DefaultDeltasPerStep * m_volumeSlider->singleStep()));
 }
 
 void VolumePopup::setDevice(AudioDevice *device)

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -59,10 +59,10 @@ signals:
     void stockIconChanged(const QString &iconName);
 
 protected:
-    void resizeEvent(QResizeEvent *event);
-    void enterEvent(QEvent *event);
-    void leaveEvent(QEvent *event);
-    bool event(QEvent * event);
+    void resizeEvent(QResizeEvent *event) override;
+    void enterEvent(QEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    bool event(QEvent * event) override;
 
 private slots:
     void handleSliderValueChanged(int value);

--- a/plugin-volume/volumepopup.h
+++ b/plugin-volume/volumepopup.h
@@ -63,6 +63,7 @@ protected:
     void enterEvent(QEvent *event) override;
     void leaveEvent(QEvent *event) override;
     bool event(QEvent * event) override;
+    bool eventFilter(QObject * watched, QEvent * event) override;
 
 private slots:
     void handleSliderValueChanged(int value);


### PR DESCRIPTION
This is a follow-up of #397 ... after all I think there is no need for the configuration if the `line-per-scroll` should be ignored for the wheel over button or slider...

closes #397 
closes lxde/lxqt#1263