### PR TITLE
Layout expand items

### DIFF
--- a/panel/lxqtpanellayout.cpp
+++ b/panel/lxqtpanellayout.cpp
@@ -701,7 +701,10 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    const int height = qMin(qMin(info.geometry.height(), geometry.height()), bh + (0 < remain-- ? 1 : 0));
+                    int height = bh + (0 < remain-- ? 1 : 0);
+                    if (!info.item->expandingDirections().testFlag(Qt::Orientation::Vertical))
+                        height = qMin(info.geometry.height(), height);
+                    height = qMin(geometry.height(), height);
                     rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
                     if (height < bh)
@@ -746,7 +749,10 @@ void LXQtPanelLayout::setGeometryHoriz(const QRect &geometry)
                 }
                 else
                 {
-                    const int height = qMin(qMin(info.geometry.height(), geometry.height()), bh + (0 < remain-- ? 1 : 0));
+                    int height = bh + (0 < remain-- ? 1 : 0);
+                    if (!info.item->expandingDirections().testFlag(Qt::Orientation::Vertical))
+                        height = qMin(info.geometry.height(), height);
+                    height = qMin(geometry.height(), height);
                     rect.setHeight(height);
                     rect.setWidth(qMin(info.geometry.width(), geometry.width()));
                     if (height < bh)
@@ -834,7 +840,10 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    const int width = qMin(qMin(info.geometry.width(), geometry.width()), bw + (0 < remain-- ? 1 : 0));
+                    int width = bw + (0 < remain-- ? 1 : 0);
+                    if (!info.item->expandingDirections().testFlag(Qt::Orientation::Horizontal))
+                        width = qMin(info.geometry.width(), width);
+                    width = qMin(geometry.width(), width);
                     rect.setWidth(width);
                     if (width < bw)
                         rect.moveCenter(QPoint(baseLines[c] + base_center, 0));
@@ -879,7 +888,10 @@ void LXQtPanelLayout::setGeometryVert(const QRect &geometry)
                 else
                 {
                     rect.setHeight(qMin(info.geometry.height(), geometry.height()));
-                    const int width = qMin(qMin(info.geometry.width(), geometry.width()), bw + (0 < remain-- ? 1 : 0));
+                    int width = bw + (0 < remain-- ? 1 : 0);
+                    if (!info.item->expandingDirections().testFlag(Qt::Orientation::Horizontal))
+                        width = qMin(info.geometry.width(), width);
+                    width = qMin(geometry.width(), width);
                     rect.setWidth(width);
                     if (width < bw)
                         rect.moveCenter(QPoint(baseLines[c] + base_center, 0));

--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -46,7 +46,8 @@ DirectoryMenu::DirectoryMenu(const ILXQtPanelPluginStartupInfo &startupInfo) :
     mOpenDirectorySignalMapper = new QSignalMapper(this);
     mMenuSignalMapper = new QSignalMapper(this);
 
-    mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    mButton.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    mButton.setAutoRaise(true);
     mButton.setIcon(XdgIcon::fromTheme("folder"));
 
     connect(&mButton, SIGNAL(clicked()), this, SLOT(showMenu()));

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -60,6 +60,7 @@ StatusNotifierButton::StatusNotifierButton(QString service, QString objectPath, 
     mFallbackIcon(QIcon::fromTheme("application-x-executable")),
     mPlugin(plugin)
 {
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoRaise(true);
     interface = new SniAsync(service, objectPath, QDBusConnection::sessionBus(), this);
 

--- a/plugin-statusnotifier/statusnotifierwidget.cpp
+++ b/plugin-statusnotifier/statusnotifierwidget.cpp
@@ -68,7 +68,6 @@ void StatusNotifierWidget::itemAdded(QString serviceAndPath)
 
     mServices.insert(serviceAndPath, button);
     layout()->addWidget(button);
-    layout()->setAlignment(button, Qt::AlignCenter);
     button->show();
 }
 

--- a/plugin-volume/volumebutton.cpp
+++ b/plugin-volume/volumebutton.cpp
@@ -46,6 +46,7 @@ VolumeButton::VolumeButton(ILXQtPanelPlugin *plugin, QWidget* parent):
         m_showOnClick(true),
         m_muteOnMiddleClick(true)
 {
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     setAutoRaise(true);
     setMouseTracking(true);
     // initial icon for button. It will be replaced after devices scan.


### PR DESCRIPTION
Fixes lxde/lxqt#374

Examples (panel width: 200, icon size: 42):
- before
![screenshot](https://cloud.githubusercontent.com/assets/10990929/26577943/64bf25aa-452e-11e7-8ec2-79ae2220c0eb.png)

- after
![screenshot](https://cloud.githubusercontent.com/assets/10990929/26577894/344a7d0c-452e-11e7-8700-e2923e190945.png)

