### PR TITLE
Avoid calling text() in MatchAction on a QAction == 0

### DIFF
--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -497,19 +497,21 @@ bool LXQtMainMenu::eventFilter(QObject *obj, QEvent *event)
                 mMenu->hide(); // close the app menu
                 return true;
             }
-            else // go to the menu item starts with the pressed key
+            else // go to the menu item which starts with the pressed key if there is an active action.
             {
                 QString key = keyEvent->text();
                 if(key.isEmpty())
                     return false;
                 QAction* action = menu->activeAction();
-                QList<QAction*> actions = menu->actions();
-                QList<QAction*>::iterator it = qFind(actions.begin(), actions.end(), action);
-                it = std::find_if(it + 1, actions.end(), MatchAction(key));
-                if(it == actions.end())
-                    it = std::find_if(actions.begin(), it, MatchAction(key));
-                if(it != actions.end())
-                    menu->setActiveAction(*it);
+                if(action !=0) {
+                    QList<QAction*> actions = menu->actions();
+                    QList<QAction*>::iterator it = qFind(actions.begin(), actions.end(), action);
+                    it = std::find_if(it + 1, actions.end(), MatchAction(key));
+                    if(it == actions.end())
+                        it = std::find_if(actions.begin(), it, MatchAction(key));
+                    if(it != actions.end())
+                        menu->setActiveAction(*it);
+                }
             }
         }
 


### PR DESCRIPTION
This only happens to (me) on FreeBSD.  
open menu push escape-> lxqt-panel crash.
open menu press enter -> lxqt-panel crash.
For some reason Debian/Openbox sets the top MenuItem to active on the same userinput so the bug does not happen there.

On Debian
open menu:
QAction(0x00) Inital QMenu::activeMenu
press Enter
QAction(0x1054210 text="Andre" toolTip="Andre" menuRole=TextHeuristicRole visible=true) (Andre = Others)

On FreeBSD [QMenu::activeAction](https://github.com/lxde/lxqt-panel/blob/master/plugin-mainmenu/lxqtmainmenu.cpp#L505)
keeps returning 0 until a MenuItem is manually selected with the mouse.