### PR TITLE
plugin-tray: Fix dupe icon display error

### DIFF
--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -387,7 +387,12 @@ void LXQtTray::onIconDestroyed(QObject * icon)
  ************************************************/
 void LXQtTray::addIcon(Window winId)
 {
-    TrayIcon* icon = new TrayIcon(winId, mIconSize, this);
+    // decline to add an icon for a window we already manage
+    TrayIcon *icon = findIcon(winId);
+    if(icon)
+        return;
+
+    icon = new TrayIcon(winId, mIconSize, this);
     mIcons.append(icon);
     mLayout->addWidget(icon);
     connect(icon, &QObject::destroyed, this, &LXQtTray::onIconDestroyed);


### PR DESCRIPTION
plugin-tray can end up with misdrawn tray icons.  The icon you can
interact with may actually draw the icon, or may instead be an empty
space.  Attempting to right click the duplicate yields the
"System tray" menu.

LXQtTray::addIcon() is being double-invoked with the same window id,
which implies a duplicate SYSTEM_TRAY_REQUEST_DOCK client message.

(possible match for https://github.com/lxde/lxqt/issues/1337, unclear from the discussion)