### PR TITLE
Use worldclock by default instead of clock.

### DIFF
--- a/panel/resources/panel.conf
+++ b/panel/resources/panel.conf
@@ -24,8 +24,8 @@ type=tray
 [mount]
 type=mount
 
-[clock]
-type=clock
+[worldclock]
+type=worldclock
 
 [volume]
 device=0


### PR DESCRIPTION
In #426 they forgot to change to using worldclock by default instead of clock when they added the deprecation notice. This fixes that.