### PR TITLE
worldclock: Fix widget size updating

### DIFF
--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -132,9 +132,13 @@ void LXQtWorldClock::updateTimeText()
 
     if (!isUpToDate)
     {
+        const QSize old_size = mContent->sizeHint();
         mContent->setText(tzNow.toString(preformat(mFormat, timeZone, tzNow)));
+        if (old_size != mContent->sizeHint())
+            mRotatedWidget->adjustContentSize();
         mRotatedWidget->update();
         updatePopupContent();
+
     }
 }
 


### PR DESCRIPTION
If the content change resulted in need of different size to show all
the content, the parent widget(s) didn't get the change. This resulted
in cut text or waste of space in panel.


ref. lxde/lxqt#1356, lxde/lxqt#632