### PR TITLE
plugin-volume: Use a specific icon for the panel

### DIFF
--- a/plugin-volume/volumepopup.cpp
+++ b/plugin-volume/volumepopup.cpp
@@ -64,7 +64,7 @@ VolumePopup::VolumePopup(QWidget* parent):
     m_volumeSlider->installEventFilter(this);
 
     m_muteToggleButton = new QPushButton(this);
-    m_muteToggleButton->setIcon(XdgIcon::fromTheme(QStringList() << "audio-volume-muted"));
+    m_muteToggleButton->setIcon(XdgIcon::fromTheme(QLatin1String("audio-volume-muted-panel")));
     m_muteToggleButton->setCheckable(true);
     m_muteToggleButton->setAutoDefault(false);
 
@@ -171,6 +171,7 @@ void VolumePopup::updateStockIcon()
     else
         iconName = "audio-volume-high";
 
+    iconName.append(QLatin1String("-panel"));
     m_muteToggleButton->setIcon(XdgIcon::fromTheme(iconName));
     emit stockIconChanged(iconName);
 }


### PR DESCRIPTION
Some "modern" icon themes have a specific panel icon for volumes.
Arc, deepin, Faenza, Faience, Flattr, matefaenza, Menda-Circle, Numix,
Numix-Light, Numix-uTouch, Paper, Papirus and it's derivatives are examples
of that.

Examle
Before:
![screen-2017-11-16-15-45-14](https://user-images.githubusercontent.com/62877/32915297-4e36c4b0-cb10-11e7-8cfc-e9fb43f11b70.png)

After:
![screen-2017-11-16-15-47-27](https://user-images.githubusercontent.com/62877/32915331-67b3b1d2-cb10-11e7-923a-e62b0b90354b.png)
