### PR TITLE
Drop Qt foreach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,13 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5DBus REQUIRED)
-find_package(Qt5LinguistTools REQUIRED)
-find_package(Qt5Xml REQUIRED)
-find_package(Qt5X11Extras REQUIRED)
+set(REQUIRED_QT_VERSION "5.7.1")
+
+find_package(Qt5Widgets ${REQUIRED_QT_VERSION} REQUIRED)
+find_package(Qt5DBus ${REQUIRED_QT_VERSION} REQUIRED)
+find_package(Qt5LinguistTools ${REQUIRED_QT_VERSION} REQUIRED)
+find_package(Qt5Xml ${REQUIRED_QT_VERSION} REQUIRED)
+find_package(Qt5X11Extras ${REQUIRED_QT_VERSION} REQUIRED)
 find_package(KF5WindowSystem REQUIRED)
 
 find_package(lxqt REQUIRED)
@@ -71,6 +73,7 @@ set(PLUGIN_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/lxqt-panel")
 add_definitions(
     -DPLUGIN_DIR=\"${PLUGIN_DIR}\"
     -DQT_USE_QSTRINGBUILDER
+    -DQT_NO_FOREACH
 )
 message(STATUS "Panel plugins location: ${PLUGIN_DIR}")
 

--- a/panel/lxqtpanel.cpp
+++ b/panel/lxqtpanel.cpp
@@ -1267,10 +1267,10 @@ void LXQtPanel::userRequestForDeletion()
     }
 
     mSettings->beginGroup(mConfigGroup);
-    QStringList plugins = mSettings->value("plugins").toStringList();
+    const QStringList plugins = mSettings->value("plugins").toStringList();
     mSettings->endGroup();
 
-    Q_FOREACH(QString i, plugins)
+    for(const QString& i : plugins)
         if (!i.isEmpty())
             mSettings->remove(i);
 

--- a/panel/lxqtpanelapplication.cpp
+++ b/panel/lxqtpanelapplication.cpp
@@ -106,7 +106,8 @@ LXQtPanelApplication::LXQtPanelApplication(int& argc, char** argv)
         d->mSettings = new LXQt::Settings(configFile, QSettings::IniFormat, this);
 
     // This is a workaround for Qt 5 bug #40681.
-    Q_FOREACH(QScreen* screen, screens())
+    const auto allScreens = screens();
+    for(QScreen* screen : allScreens)
     {
         connect(screen, &QScreen::destroyed, this, &LXQtPanelApplication::screenDestroyed);
     }
@@ -121,7 +122,7 @@ LXQtPanelApplication::LXQtPanelApplication(int& argc, char** argv)
         panels << "panel1";
     }
 
-    Q_FOREACH(QString i, panels)
+    for(const QString& i : qAsConst(panels))
     {
         addPanel(i);
     }
@@ -185,11 +186,11 @@ void LXQtPanelApplication::reloadPanelsAsNeeded()
     // LXQtPanelApplication::screenDestroyed().
 
     // qDebug() << "LXQtPanelApplication::reloadPanelsAsNeeded()";
-    QStringList names = d->mSettings->value("panels").toStringList();
-    Q_FOREACH(const QString& name, names)
+    const QStringList names = d->mSettings->value("panels").toStringList();
+    for(const QString& name : names)
     {
         bool found = false;
-        Q_FOREACH(LXQtPanel* panel, mPanels)
+        for(LXQtPanel* panel : qAsConst(mPanels))
         {
             if(panel->name() == name)
             {
@@ -236,7 +237,7 @@ void LXQtPanelApplication::screenDestroyed(QObject* screenObj)
     QScreen* screen = static_cast<QScreen*>(screenObj);
     bool reloadNeeded = false;
     qApp->setQuitOnLastWindowClosed(false);
-    Q_FOREACH(LXQtPanel* panel, mPanels)
+    for(LXQtPanel* panel : qAsConst(mPanels))
     {
         QWindow* panelWindow = panel->windowHandle();
         if(panelWindow && panelWindow->screen() == screen)

--- a/panel/lxqtpanellayout.cpp
+++ b/panel/lxqtpanellayout.cpp
@@ -220,7 +220,7 @@ void LayoutItemGrid::rebuild()
 {
     clear();
 
-    foreach(QLayoutItem *item, mItems)
+    for(QLayoutItem *item : qAsConst(mItems))
     {
         doAddToGrid(item);
     }

--- a/panel/plugin.cpp
+++ b/panel/plugin.cpp
@@ -104,7 +104,7 @@ Plugin::Plugin(const LXQt::PluginInfo &desktopFile, LXQt::Settings *settings, co
     else {
         // this plugin is a dynamically loadable module
         QString baseName = QString("lib%1.so").arg(desktopFile.id());
-        foreach(const QString &dirName, dirs)
+        for(const QString &dirName : qAsConst(dirs))
         {
             QFileInfo fi(QDir(dirName), baseName);
             if (fi.exists())

--- a/plugin-directorymenu/directorymenu.cpp
+++ b/plugin-directorymenu/directorymenu.cpp
@@ -125,9 +125,9 @@ void DirectoryMenu::addActions(QMenu* menu, const QString& path)
     menu->addSeparator();
 
     QDir dir(path);
-    QFileInfoList list = dir.entryInfoList();
+    const QFileInfoList list = dir.entryInfoList();
 
-    foreach (const QFileInfo& entry, list)
+    for (const QFileInfo& entry : list)
     {
         if(entry.isDir() && !entry.isHidden())
         {

--- a/plugin-mainmenu/lxqtmainmenu.cpp
+++ b/plugin-mainmenu/lxqtmainmenu.cpp
@@ -423,8 +423,8 @@ void LXQtMainMenu::setMenuFontSize()
     if (mMenu->font() != menuFont)
     {
         mMenu->setFont(menuFont);
-        QList<QMenu*> subMenuList = mMenu->findChildren<QMenu*>();
-        foreach (QMenu* subMenu, subMenuList)
+        const QList<QMenu*> subMenuList = mMenu->findChildren<QMenu*>();
+        for (QMenu* const subMenu : subMenuList)
         {
             subMenu->setFont(menuFont);
         }

--- a/plugin-mainmenu/xdgcachedmenu.cpp
+++ b/plugin-mainmenu/xdgcachedmenu.cpp
@@ -193,7 +193,8 @@ void XdgCachedMenu::handleMouseMoveEvent(QMouseEvent *event)
 
 void XdgCachedMenu::onAboutToShow()
 {
-    Q_FOREACH(QAction* action, actions())
+    const auto actionList = actions();
+    for(QAction* action : actionList)
     {
         if(action->inherits("XdgCachedMenuAction"))
         {

--- a/plugin-quicklaunch/lxqtquicklaunch.cpp
+++ b/plugin-quicklaunch/lxqtquicklaunch.cpp
@@ -186,9 +186,8 @@ void LXQtQuickLaunch::dragEnterEvent(QDragEnterEvent *e)
 
 void LXQtQuickLaunch::dropEvent(QDropEvent *e)
 {
-    const QMimeData *mime = e->mimeData();
-
-    foreach (const QUrl &url, mime->urls().toSet())
+    const auto urls = e->mimeData()->urls().toSet();
+    for (const QUrl &url : urls)
     {
         QString fileName(url.isLocalFile() ? url.toLocalFile() : url.url());
         QFileInfo fi(fileName);

--- a/plugin-statusnotifier/statusnotifierbutton.cpp
+++ b/plugin-statusnotifier/statusnotifierbutton.cpp
@@ -149,10 +149,10 @@ void StatusNotifierButton::refetchIcon(Status status)
                     if (themeDir.cd("hicolor") || (themeDir.cd("icons") && themeDir.cd("hicolor")))
                     {
                         const QStringList sizes = themeDir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
-                        foreach (const QString &dir, sizes)
+                        for (const QString &dir : sizes)
                         {
                             const QStringList dirs = QDir(themeDir.filePath(dir)).entryList(QDir::AllDirs | QDir::NoDotAndDotDot);
-                            foreach (const QString &innerDir, dirs)
+                            for (const QString &innerDir : dirs)
                             {
                                 QString file = themeDir.absolutePath() + "/" + dir + "/" + innerDir + "/" + iconName + ".png";
                                 if (QFile::exists(file))

--- a/plugin-taskbar/lxqttaskgroup.cpp
+++ b/plugin-taskbar/lxqttaskgroup.cpp
@@ -97,7 +97,7 @@ void LXQtTaskGroup::contextMenuEvent(QContextMenuEvent *event)
  ************************************************/
 void LXQtTaskGroup::closeGroup()
 {
-    foreach (LXQtTaskButton * button, mButtonHash.values())
+    for (LXQtTaskButton *button : qAsConst(mButtonHash) )
         if (button->isOnDesktop(KWindowSystem::currentDesktop()))
             button->closeApplication();
 }
@@ -133,7 +133,7 @@ LXQtTaskButton * LXQtTaskGroup::addWindow(WId id)
  ************************************************/
 LXQtTaskButton * LXQtTaskGroup::checkedButton() const
 {
-    foreach (LXQtTaskButton* button, mButtonHash.values())
+    for (LXQtTaskButton* button : qAsConst(mButtonHash))
         if (button->isChecked())
             return button;
 
@@ -192,7 +192,7 @@ LXQtTaskButton * LXQtTaskGroup::getNextPrevChildButton(bool next, bool circular)
 void LXQtTaskGroup::onActiveWindowChanged(WId window)
 {
     LXQtTaskButton *button = mButtonHash.value(window, nullptr);
-    foreach (LXQtTaskButton *btn, mButtonHash.values())
+    for (LXQtTaskButton *btn : qAsConst(mButtonHash))
         btn->setChecked(false);
 
     if (button)
@@ -284,7 +284,7 @@ int LXQtTaskGroup::buttonsCount() const
 int LXQtTaskGroup::visibleButtonsCount() const
 {
     int i = 0;
-    foreach (LXQtTaskButton *btn, mButtonHash.values())
+    for (LXQtTaskButton *btn : qAsConst(mButtonHash))
         if (btn->isVisibleTo(mPopup))
             i++;
     return i;
@@ -324,7 +324,7 @@ void LXQtTaskGroup::regroup()
         mSingleButton = true;
         // Get first visible button
         LXQtTaskButton * button = NULL;
-        foreach (LXQtTaskButton *btn, mButtonHash.values())
+        for (LXQtTaskButton *btn : qAsConst(mButtonHash))
         {
             if (btn->isVisibleTo(mPopup))
             {
@@ -369,7 +369,7 @@ void LXQtTaskGroup::recalculateFrameIfVisible()
  ************************************************/
 void LXQtTaskGroup::setAutoRotation(bool value, ILXQtPanel::Position position)
 {
-    foreach (LXQtTaskButton *button, mButtonHash.values())
+    for (LXQtTaskButton *button : qAsConst(mButtonHash))
         button->setAutoRotation(false, position);
 
     LXQtTaskButton::setAutoRotation(value, position);
@@ -383,7 +383,7 @@ void LXQtTaskGroup::refreshVisibility()
     bool will = false;
     LXQtTaskBar const * taskbar = parentTaskBar();
     const int showDesktop = taskbar->showDesktopNum();
-    foreach(LXQtTaskButton * btn, mButtonHash.values())
+    for(LXQtTaskButton * btn : qAsConst(mButtonHash))
     {
         bool visible = taskbar->isShowOnlyOneDesktopTasks() ? btn->isOnDesktop(0 == showDesktop ? KWindowSystem::currentDesktop() : showDesktop) : true;
         visible &= taskbar->isShowOnlyCurrentScreenTasks() ? btn->isOnCurrentScreen() : true;
@@ -449,7 +449,7 @@ void LXQtTaskGroup::refreshIconsGeometry()
         return;
     }
 
-    foreach(LXQtTaskButton *but, mButtonHash.values())
+    for(LXQtTaskButton *but : qAsConst(mButtonHash))
     {
         but->refreshIconGeometry(rect);
         but->setIconSize(QSize(plugin()->panel()->iconSize(), plugin()->panel()->iconSize()));
@@ -493,7 +493,7 @@ int LXQtTaskGroup::recalculateFrameWidth() const
     const QFontMetrics fm = fontMetrics();
     int max = 100 * fm.width (' '); // elide after the max width
     int txtWidth = 0;
-    foreach (LXQtTaskButton *btn, mButtonHash.values())
+    for (LXQtTaskButton *btn : qAsConst(mButtonHash))
         txtWidth = qMax(fm.width(btn->text()), txtWidth);
     return iconSize().width() + qMin(txtWidth, max) + 30/* give enough room to margins and borders*/;
 }

--- a/plugin-tray/lxqttray.cpp
+++ b/plugin-tray/lxqttray.cpp
@@ -212,7 +212,7 @@ void LXQtTray::clientMessageEvent(xcb_generic_event_t *e)
  ************************************************/
 TrayIcon* LXQtTray::findIcon(Window id)
 {
-    foreach(TrayIcon* icon, mIcons)
+    for(TrayIcon* icon : qAsConst(mIcons))
     {
         if (icon->iconId() == id || icon->windowId() == id)
             return icon;

--- a/plugin-volume/alsaengine.cpp
+++ b/plugin-volume/alsaengine.cpp
@@ -70,7 +70,7 @@ int AlsaEngine::volumeMax(AudioDevice *device) const
 
 AlsaDevice *AlsaEngine::getDeviceByAlsaElem(snd_mixer_elem_t *elem) const
 {
-    foreach (AudioDevice *device, m_sinks) {
+    for (AudioDevice *device : qAsConst(m_sinks)) {
         AlsaDevice *dev = qobject_cast<AlsaDevice*>(device);
         if (!dev || !dev->element())
             continue;

--- a/plugin-volume/lxqtvolumeconfiguration.cpp
+++ b/plugin-volume/lxqtvolumeconfiguration.cpp
@@ -84,7 +84,7 @@ void LXQtVolumeConfiguration::setSinkList(const QList<AudioDevice *> sinks)
     const bool old_block = ui->devAddedCombo->blockSignals(true);
     ui->devAddedCombo->clear();
 
-    foreach (const AudioDevice *dev, sinks) {
+    for (const AudioDevice *dev : qAsConst(sinks)) {
         ui->devAddedCombo->addItem(dev->description(), dev->index());
     }
 

--- a/plugin-volume/pulseaudioengine.cpp
+++ b/plugin-volume/pulseaudioengine.cpp
@@ -187,7 +187,7 @@ void PulseAudioEngine::addOrUpdateSink(const pa_sink_info *info)
     bool newSink = false;
     QString name = QString::fromUtf8(info->name);
 
-    foreach (AudioDevice *device, m_sinks) {
+    for (AudioDevice *device : qAsConst(m_sinks)) {
         if (device->name() == name) {
             dev = device;
             break;

--- a/plugin-worldclock/lxqtworldclock.cpp
+++ b/plugin-worldclock/lxqtworldclock.cpp
@@ -448,7 +448,7 @@ void LXQtWorldClock::updatePopupContent()
         QStringList allTimeZones;
         bool hasTimeZone = formatHasTimeZone(mFormat);
 
-        foreach (QString timeZoneName, mTimeZones)
+        for (QString timeZoneName : qAsConst(mTimeZones))
         {
             if (timeZoneName == QLatin1String("local"))
                 timeZoneName = QString::fromLatin1(QTimeZone::systemTimeZoneId());

--- a/plugin-worldclock/lxqtworldclockconfiguration.cpp
+++ b/plugin-worldclock/lxqtworldclockconfiguration.cpp
@@ -488,7 +488,7 @@ void LXQtWorldClockConfiguration::updateTimeZoneButtons()
 int LXQtWorldClockConfiguration::findTimeZone(const QString& timeZone)
 {
     QList<QTableWidgetItem*> items = ui->timeZonesTW->findItems(timeZone, Qt::MatchExactly);
-    foreach (QTableWidgetItem* item, items)
+    for (const QTableWidgetItem* item : qAsConst(items))
         if (item->column() == 0)
             return item->row();
     return -1;
@@ -522,7 +522,8 @@ void LXQtWorldClockConfiguration::addTimeZone()
 
 void LXQtWorldClockConfiguration::removeTimeZone()
 {
-    foreach (QTableWidgetItem *item, ui->timeZonesTW->selectedItems())
+    const auto selectedItems = ui->timeZonesTW->selectedItems();
+    for (const QTableWidgetItem *item : selectedItems)
         if (item->column() == 0)
         {
             if (item->text() == mDefaultTimeZone)

--- a/plugin-worldclock/lxqtworldclockconfigurationtimezones.cpp
+++ b/plugin-worldclock/lxqtworldclockconfigurationtimezones.cpp
@@ -106,7 +106,8 @@ int LXQtWorldClockConfigurationTimeZones::updateAndExec()
 
     QMap<QString, QTreeWidgetItem*> parentItems;
 
-    foreach(const QByteArray &ba, QTimeZone::availableTimeZoneIds())
+    const auto timeZones = QTimeZone::availableTimeZoneIds();
+    for(const QByteArray &ba : timeZones)
     {
         QTimeZone timeZone(ba);
         QString ianaId(ba);


### PR DESCRIPTION
Replaced by the ranged-based for loop.
Qt 5.7.1 is required. We use qAsConst().
The replacement brings some performance improvements. Container detachments
and container anti-pattern use were fixed.