### PR TITLE
Move and Resize items in task-button context menu

### DIFF
--- a/plugin-taskbar/lxqttaskbutton.h
+++ b/plugin-taskbar/lxqttaskbutton.h
@@ -95,6 +95,8 @@ public slots:
     void unShadeApplication();
     void closeApplication();
     void moveApplicationToDesktop();
+    void moveApplication();
+    void resizeApplication();
     void setApplicationLayer();
 
     void setOrigin(Qt::Corner);


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1434.

NOTE: Since different window managers may show different behaviors in the case of maximized and fullscreen states, movement/resizing is disabled with those states.