### PR TITLE
Set the initial task button text (and icon) correctly

### DIFF
--- a/plugin-taskbar/lxqttaskbar.cpp
+++ b/plugin-taskbar/lxqttaskbar.cpp
@@ -93,7 +93,6 @@ LXQtTaskBar::LXQtTaskBar(ILXQtPanelPlugin *plugin, QWidget *parent) :
     connect(mSignalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &LXQtTaskBar::activateTask);
     QTimer::singleShot(0, this, &LXQtTaskBar::registerShortcuts);
 
-    connect(KWindowSystem::self(), SIGNAL(stackingOrderChanged()), SLOT(refreshTaskList()));
     connect(KWindowSystem::self(), static_cast<void (KWindowSystem::*)(WId, NET::Properties, NET::Properties2)>(&KWindowSystem::windowChanged)
             , this, &LXQtTaskBar::onWindowChanged);
     connect(KWindowSystem::self(), &KWindowSystem::windowAdded, this, &LXQtTaskBar::onWindowAdded);


### PR DESCRIPTION
Fixes https://github.com/lxde/lxqt/issues/1303.

Detailed explanation:

When a window shows up, the signal `KWindowSystem::stackingOrderChanged` is emitted *before* `KWindowSystem::windowAdded`. The former signal is connected to the function `LXQtTaskBar::refreshTaskList()`, which calls the functions `LXQtTaskBar::addWindow()` and `LXQtTaskBar::removeWindow()` to add and remove monitored windows.

Connecting `LXQtTaskBar::refreshTaskList()` to the signal `KWindowSystem::stackingOrderChanged` not only is redundant but also causes a problem:

(1) It's redundant because the job of adding *new* windows should be done by `LXQtTaskBar::onWindowAdded()` connected to the signal `KWindowSystem::windowAdded`. However, with the current code, `LXQtTaskBar::addWindow()` is never called by that function because the new window is already added through `KWindowSystem::stackingOrderChanged`. Similarly, `LXQtTaskBar::onWindowRemoved()` should be responsible for removing windows by being connected to the signal `KWindowSystem::windowRemoved`.

(2) More importantly, as the window name can change in the short interval between the emissions of `KWindowSystem::stackingOrderChanged` and `KWindowSystem::windowAdded`, the corresponding taskbar button may get a wrong text. The reason is that the signal `KWindowSystem::windowChanged` announces changes only starting from the emission of `KWindowSystem::windowAdded`. (Theoretically, the initial icon might also be wrong but that's rarer).

Here, the connection to `KWindowSystem::stackingOrderChanged` is removed, so that the initial task button text/icon is set correctly. In this way, several useless calls to `LXQtTaskBar::refreshTaskList()` are also prevented when a window is shown/closed or focused/unfocused.